### PR TITLE
feat: add child_creator pub method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,6 +115,10 @@ impl RequestAuxData {
     fn new(child_creator: NodeIndex) -> Self {
         RequestAuxData { child_creator }
     }
+
+    pub fn child_creator(&self) -> NodeIndex {
+        self.child_creator
+    }
 }
 
 /// Type for incoming notifications: Environment to Consensus.


### PR DESCRIPTION
Small change, required pub method for `aleph-node`.