### PR TITLE
Add support for asynchronous signing in KeyBox

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ log = "0.4"
 rand = "0.8"
 async-trait = "0.1"
 codec = { package = "parity-scale-codec", version = "2", default-features = false, features = ["derive"] }
+parking_lot = "0.11"
 
 [dev-dependencies]
 tokio = { version = "1.6.1", features = ["macros", "rt", "rt-multi-thread"] }

--- a/examples/dummy_honest.rs
+++ b/examples/dummy_honest.rs
@@ -1,4 +1,5 @@
 use aleph_bft::{NodeIndex, OrderedBatch};
+use async_trait::async_trait;
 use codec::{Decode, Encode};
 use futures::{
     channel::{
@@ -175,9 +176,10 @@ struct KeyBox {
     index: NodeIndex,
 }
 
+#[async_trait]
 impl aleph_bft::KeyBox for KeyBox {
     type Signature = Signature;
-    fn sign(&self, _msg: &[u8]) -> Self::Signature {
+    async fn sign(&self, _msg: &[u8]) -> Self::Signature {
         Signature {}
     }
     fn verify(&self, _msg: &[u8], _sgn: &Self::Signature, _index: NodeIndex) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,17 @@ pub trait Index {
 /// A hasher, used for creating identifiers for blocks or units.
 pub trait Hasher: Eq + Clone + Send + Sync + Debug + 'static {
     /// A hash, as an identifier for a block or unit.
-    type Hash: AsRef<[u8]> + Eq + Ord + Copy + Clone + Send + Debug + StdHash + Encode + Decode;
+    type Hash: AsRef<[u8]>
+        + Eq
+        + Ord
+        + Copy
+        + Clone
+        + Send
+        + Sync
+        + Debug
+        + StdHash
+        + Encode
+        + Decode;
 
     fn hash(s: &[u8]) -> Self::Hash;
 }

--- a/src/testing/mock.rs
+++ b/src/testing/mock.rs
@@ -1,7 +1,5 @@
+use async_trait::async_trait;
 use codec::{Decode, Encode};
-use log::{debug, error};
-use parking_lot::Mutex;
-
 use futures::{
     channel::{
         mpsc::{unbounded, UnboundedReceiver, UnboundedSender},
@@ -9,6 +7,8 @@ use futures::{
     },
     Future, StreamExt,
 };
+use log::{debug, error};
+use parking_lot::Mutex;
 
 use std::{
     cell::Cell,
@@ -467,9 +467,10 @@ impl Index for KeyBox {
     }
 }
 
+#[async_trait]
 impl KeyBoxT for KeyBox {
     type Signature = Signature;
-    fn sign(&self, _msg: &[u8]) -> Signature {
+    async fn sign(&self, _msg: &[u8]) -> Signature {
         Signature {}
     }
     fn verify(&self, _msg: &[u8], _sgn: &Signature, _index: NodeIndex) -> bool {

--- a/src/testing/rmc.rs
+++ b/src/testing/rmc.rs
@@ -155,7 +155,7 @@ async fn simple_scenario() {
 
     let hash = Hash { byte: 56 };
     for i in 0..node_count.0 {
-        data.rmcs[i].start_rmc(hash);
+        data.rmcs[i].start_rmc(hash).await;
     }
 
     let hashes = data.collect_multisigned_hashes(node_count.0).await;
@@ -177,7 +177,7 @@ async fn faulty_network() {
 
     let hash = Hash { byte: 56 };
     for i in 0..node_count.0 {
-        data.rmcs[i].start_rmc(hash);
+        data.rmcs[i].start_rmc(hash).await;
     }
 
     let hashes = data.collect_multisigned_hashes(node_count.0).await;
@@ -202,7 +202,7 @@ async fn node_hearing_only_multisignatures() {
     let threshold = (2 * node_count.0 + 1) / 3;
     let hash = Hash { byte: 56 };
     for i in 0..threshold {
-        data.rmcs[i].start_rmc(hash);
+        data.rmcs[i].start_rmc(hash).await;
     }
 
     let hashes = data.collect_multisigned_hashes(node_count.0).await;
@@ -247,7 +247,7 @@ async fn bad_signatures_and_multisignatures_are_ignored() {
 
     let hash = Hash { byte: 56 };
     for i in 0..node_count.0 {
-        data.rmcs[i].start_rmc(hash);
+        data.rmcs[i].start_rmc(hash).await;
     }
 
     let hashes = data.collect_multisigned_hashes(node_count.0).await;


### PR DESCRIPTION
Modify the `KeyBox` trait so that the `sign` method is `async`. This is because blocking signing in deprecated in substrate.
