### PR TITLE
Add simple multisignatures to AlephBFT

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-bft"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2018"
 authors = ["Cardinal Cryptography"]
 categories = ["algorithms", "data-structures", "cryptography", "database"]

--- a/examples/dummy_honest.rs
+++ b/examples/dummy_honest.rs
@@ -1,4 +1,4 @@
-use aleph_bft::{NodeIndex, OrderedBatch};
+use aleph_bft::{NodeCount, NodeIndex, OrderedBatch};
 use async_trait::async_trait;
 use codec::{Decode, Encode};
 use futures::{
@@ -179,6 +179,11 @@ struct KeyBox {
 #[async_trait]
 impl aleph_bft::KeyBox for KeyBox {
     type Signature = Signature;
+
+    fn node_count(&self) -> NodeCount {
+        self.count.into()
+    }
+
     async fn sign(&self, _msg: &[u8]) -> Self::Signature {
         Signature {}
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,12 +6,12 @@ use codec::{Decode, Encode};
 use futures::{channel::mpsc, Future};
 use std::{fmt::Debug, hash::Hash as StdHash, pin::Pin};
 
-use crate::nodes::{NodeCount, NodeMap};
+use crate::nodes::NodeMap;
 
 pub use config::{default_config, Config, DelayConfig};
 pub use member::Member;
 pub use network::{Network, NetworkData};
-pub use nodes::NodeIndex;
+pub use nodes::{NodeCount, NodeIndex};
 
 mod alerts;
 mod consensus;

--- a/src/testing/mock.rs
+++ b/src/testing/mock.rs
@@ -470,9 +470,15 @@ impl Index for KeyBox {
 #[async_trait]
 impl KeyBoxT for KeyBox {
     type Signature = Signature;
+
+    fn node_count(&self) -> NodeCount {
+        self.count
+    }
+
     async fn sign(&self, _msg: &[u8]) -> Signature {
         Signature {}
     }
+
     fn verify(&self, _msg: &[u8], _sgn: &Signature, _index: NodeIndex) -> bool {
         true
     }


### PR DESCRIPTION
This PR adds a `DefaultMultiKeychain<KB: KeyBox>` struct, which is a simple implementation of `MultiKeyChain` where a multisignature is simply a list of signatures.