### PR TITLE
Clean up `signed` interface

### DIFF
--- a/src/rmc.rs
+++ b/src/rmc.rs
@@ -31,7 +31,7 @@ pub enum Message<H: Signable, S: Signature, M: PartialMultisignature> {
 impl<H: Signable, S: Signature, M: PartialMultisignature> Message<H, S, M> {
     pub fn hash(&self) -> &H {
         match self {
-            Message::SignedHash(unchecked) => unchecked.as_signable().as_signable(),
+            Message::SignedHash(unchecked) => unchecked.as_signable_strip_index(),
             Message::MultisignedHash(unchecked) => unchecked.as_signable(),
         }
     }
@@ -212,8 +212,7 @@ impl<'a, H: Signable + Hash + Eq + Clone + Debug, MK: MultiKeychain> ReliableMul
 
     /// Initiate a new instance of RMC for `hash`.
     pub async fn start_rmc(&mut self, hash: H) {
-        let indexed_hash = Indexed::new(hash, self.keychain.index());
-        let signed_hash = Signed::sign(indexed_hash, self.keychain).await;
+        let signed_hash = Signed::sign_with_index(hash, self.keychain).await;
         let message = Message::SignedHash(signed_hash.into_unchecked());
         self.handle_message(message.clone());
         self.scheduler.add_task(Task::BroadcastMessage(message))

--- a/src/testing/alerts.rs
+++ b/src/testing/alerts.rs
@@ -100,7 +100,7 @@ impl TestCase {
         to_sign: T,
         signer: NodeIndex,
     ) -> UncheckedSigned<Indexed<T>, Signature> {
-        Signed::sign(Indexed::new(to_sign, signer), self.keychain(signer))
+        Signed::sign_with_index(to_sign, self.keychain(signer))
             .await
             .into()
     }

--- a/src/testing/rmc.rs
+++ b/src/testing/rmc.rs
@@ -235,8 +235,9 @@ async fn bad_signatures_and_multisignatures_are_ignored() {
     let mut data = TestData::new(node_count, &keychains, |_, _| true);
 
     let bad_hash = Hash { byte: 65 };
-    let bad_msg = TestMessage::SignedHash(UncheckedSigned::new(
-        Indexed::new(bad_hash, 0.into()),
+    let bad_msg = TestMessage::SignedHash(UncheckedSigned::new_with_index(
+        bad_hash,
+        0.into(),
         bad_signature(),
     ));
     data.network.broadcast_message(bad_msg);


### PR DESCRIPTION
Mostly make the `Indexed` wrapper more transparent, but also some
improvements to documentation and a more uniform interface.