### PR TITLE
TOB-ALEPH-002 (consistent usage of Round)

### DIFF
--- a/src/alerts.rs
+++ b/src/alerts.rs
@@ -217,7 +217,7 @@ impl<'a, H: Hasher, D: Data, MK: MultiKeychain> Alerter<'a, H, D, MK> {
             warn!(target: "AlephBFT-alerter", "{:?} Too many units: {} included in alert.", self.index(), units.len());
             return false;
         }
-        let mut rounds: HashSet<usize> = HashSet::new();
+        let mut rounds = HashSet::new();
         for u in units {
             let u = match u.clone().check(self.keychain) {
                 Ok(u) => u,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use crate::SessionId;
+use crate::{Round, SessionId};
 use std::{sync::Arc, time::Duration};
 
 use crate::nodes::{NodeCount, NodeIndex};
@@ -31,11 +31,11 @@ pub struct Config {
     /// Configuration of several parameters related to delaying various tasks.
     pub delay_config: DelayConfig,
     /// All units (except alerted ones) that are higher by >= rounds_margin then our local round number, are ignored.
-    pub rounds_margin: usize,
+    pub rounds_margin: Round,
     /// Maximum number of units that can be attached to an alert.
     pub max_units_per_alert: usize,
     /// Maximum allowable round of a unit.
-    pub max_round: usize,
+    pub max_round: Round,
 }
 
 pub(crate) fn exponential_slowdown(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ pub trait Data: Eq + Clone + Send + Sync + Debug + StdHash + Encode + Decode + '
 impl<T> Data for T where T: Eq + Clone + Send + Sync + Debug + StdHash + Encode + Decode + 'static {}
 
 /// An asynchronous round of the protocol.
-pub type Round = usize;
+pub type Round = u16;
 
 /// Type for sending a new ordered batch of data items.
 pub type OrderedBatch<Data> = Vec<Data>;

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 /// The index of a node
-#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Hash, From)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, PartialOrd, Hash, From)]
 pub struct NodeIndex(pub usize);
 
 impl Encode for NodeIndex {
@@ -27,7 +27,8 @@ impl Decode for NodeIndex {
     }
 }
 
-/// Node count -- if necessary this can be then generalized to weights
+/// Node count. Right now it doubles as node weight in many places in the code, in the future we
+/// might need a new type for that.
 #[derive(
     Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Add, Sub, AddAssign, SubAssign, Sum, From, Into,
 )]
@@ -45,6 +46,19 @@ impl Div<usize> for NodeCount {
     type Output = Self;
     fn div(self, rhs: usize) -> Self::Output {
         NodeCount(self.0 / rhs)
+    }
+}
+
+impl NodeCount {
+    pub fn into_range(self) -> core::ops::Range<NodeIndex> {
+        core::ops::Range {
+            start: 0.into(),
+            end: self.0.into(),
+        }
+    }
+
+    pub fn into_iterator(self) -> impl Iterator<Item = NodeIndex> {
+        (0..self.0).into_iter().map(NodeIndex)
     }
 }
 

--- a/src/testing/crash.rs
+++ b/src/testing/crash.rs
@@ -2,12 +2,12 @@ use futures::StreamExt;
 
 use crate::{
     testing::mock::{configure_network, init_log, spawn_honest_member, Spawner},
-    SpawnHandle,
+    Index, NodeCount, SpawnHandle,
 };
 
 async fn honest_members_agree_on_batches(
-    n_members: usize,
-    n_alive: usize,
+    n_members: NodeCount,
+    n_alive: NodeCount,
     n_batches: usize,
     network_reliability: f64,
 ) {
@@ -18,10 +18,11 @@ async fn honest_members_agree_on_batches(
     let (net_hub, mut networks) = configure_network(n_members, network_reliability);
     spawner.spawn("network-hub", net_hub);
 
-    for (ix, network) in networks.iter_mut().enumerate() {
-        if ix < n_alive {
-            let (batch_rx, exit_tx) =
-                spawn_honest_member(spawner.clone(), ix, n_members, network.take().unwrap());
+    for network in networks.iter_mut() {
+        let network = network.take().unwrap();
+        let ix = network.index();
+        if n_alive.into_range().contains(&ix) {
+            let (batch_rx, exit_tx) = spawn_honest_member(spawner.clone(), ix, n_members, network);
             batch_rxs.push(batch_rx);
             exits.push(exit_tx);
         }
@@ -37,37 +38,37 @@ async fn honest_members_agree_on_batches(
         batches.push(batches_per_ix);
     }
 
-    for node_ix in 1..n_alive {
-        assert_eq!(batches[0], batches[node_ix]);
+    for node_ix in n_alive.into_iterator().skip(1) {
+        assert_eq!(batches[0], batches[node_ix.0]);
     }
 }
 
 #[tokio::test]
 async fn small_honest_all_alive() {
-    honest_members_agree_on_batches(4, 4, 5, 1.0).await;
+    honest_members_agree_on_batches(4.into(), 4.into(), 5, 1.0).await;
 }
 
 #[tokio::test]
 async fn small_honest_one_crash() {
-    honest_members_agree_on_batches(4, 3, 5, 1.0).await;
+    honest_members_agree_on_batches(4.into(), 3.into(), 5, 1.0).await;
 }
 
 #[tokio::test]
 async fn small_honest_one_crash_unreliable_network() {
-    honest_members_agree_on_batches(4, 3, 5, 0.9).await;
+    honest_members_agree_on_batches(4.into(), 3.into(), 5, 0.9).await;
 }
 
 #[tokio::test]
 async fn medium_honest_all_alive() {
-    honest_members_agree_on_batches(31, 31, 5, 1.0).await;
+    honest_members_agree_on_batches(31.into(), 31.into(), 5, 1.0).await;
 }
 
 #[tokio::test]
 async fn medium_honest_ten_crashes() {
-    honest_members_agree_on_batches(31, 21, 5, 1.0).await;
+    honest_members_agree_on_batches(31.into(), 21.into(), 5, 1.0).await;
 }
 
 #[tokio::test]
 async fn medium_honest_ten_crashes_unreliable_network() {
-    honest_members_agree_on_batches(31, 21, 5, 0.9).await;
+    honest_members_agree_on_batches(31.into(), 21.into(), 5, 0.9).await;
 }

--- a/src/units.rs
+++ b/src/units.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Encode, Decode, Hash)]
 pub(crate) struct UnitCoord {
-    pub(crate) round: u16,
+    round: Round,
     creator: NodeIndex,
 }
 
@@ -26,7 +26,7 @@ impl UnitCoord {
     }
 
     pub fn round(&self) -> Round {
-        self.round as Round
+        self.round
     }
 }
 
@@ -173,7 +173,7 @@ impl<H: Hasher, D: Data> FullUnit<H, D> {
     }
     #[cfg(test)]
     pub(crate) fn set_round(&mut self, round: Round) {
-        self.pre_unit.coord.round = round as u16
+        self.pre_unit.coord.round = round
     }
 }
 


### PR DESCRIPTION
Also makes usage of `NodeIndex` and `NodeCount` more consistent, since it was a natural opportunity to do this.