### PR TITLE
Fix of TOB-ALEPH-009 (Inconsistent closed channel error handling) 

### DIFF
--- a/src/creator.rs
+++ b/src/creator.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use futures::{channel::oneshot, FutureExt, StreamExt};
 use futures_timer::Delay;
-use log::{error, info, trace, warn};
+use log::{info, trace, warn};
 use std::time::Duration;
 
 /// A process responsible for creating new units. It receives all the units added locally to the Dag
@@ -66,7 +66,7 @@ impl<H: Hasher> Creator<H> {
         }
     }
 
-    fn create_unit(&mut self) -> Result<(), ()> {
+    fn create_unit(&mut self) {
         let round = self.current_round;
         let parents = {
             if round == 0 {
@@ -80,18 +80,12 @@ impl<H: Hasher> Creator<H> {
 
         let new_preunit = PreUnit::new(self.node_ix, round, control_hash);
         trace!(target: "AlephBFT-creator", "{:?} Created a new unit {:?} at round {:?}.", self.node_ix, new_preunit, self.current_round);
-        self
-            .new_units_tx
+        self.new_units_tx
             .unbounded_send(NotificationOut::CreatedPreUnit(new_preunit))
-            .map_err(|e|
-        {
-            error!(target: "AlephBFT-creator", "{:?} notification channel is closed {:?}, closing", self.node_ix, e);
-        })?;
+            .expect("Notification channel should be open");
 
         self.current_round += 1;
         self.init_round(self.current_round);
-
-        Ok(())
     }
 
     fn add_unit(&mut self, round: Round, pid: NodeIndex, hash: H::Hash) {
@@ -148,9 +142,7 @@ impl<H: Hasher> Creator<H> {
                 },
             };
             if delay_passed && self.check_ready() {
-                if self.create_unit().is_err() {
-                    break;
-                };
+                self.create_unit();
                 delay_fut = Delay::new((self.create_lag)(round + 1)).fuse();
                 round += 1;
                 delay_passed = false;

--- a/src/member.rs
+++ b/src/member.rs
@@ -167,7 +167,7 @@ where
             .as_ref()
             .unwrap()
             .unbounded_send(notification)
-            .expect("channel to consensus should be open")
+            .expect("Channel to consensus should be open")
     }
 
     async fn on_create(&mut self, u: PreUnit<H>) {
@@ -221,7 +221,7 @@ where
             .as_ref()
             .unwrap()
             .unbounded_send((message, Recipient::Node(peer_id)))
-            .expect("channel to network should be open")
+            .expect("Channel to network should be open")
     }
 
     fn broadcast_units(&mut self, message: UnitMessage<H, D, MK::Signature>) {
@@ -229,7 +229,7 @@ where
             .as_ref()
             .unwrap()
             .unbounded_send((message, Recipient::Everyone))
-            .expect("channel to network should be open")
+            .expect("Channel to network should be open")
     }
 
     fn schedule_parents_request(&mut self, u_hash: H::Hash, curr_time: time::Instant) {
@@ -435,7 +435,7 @@ where
                                 .as_ref()
                                 .unwrap()
                                 .unbounded_send(NotificationIn::NewUnits(vec![unit]))
-                                .expect("channel to consensus should be open");
+                                .expect("Channel to consensus should be open");
                         }
                     });
             } else {
@@ -589,7 +589,7 @@ where
             .as_ref()
             .unwrap()
             .unbounded_send(alert)
-            .expect("channel to alerter should be open")
+            .expect("Channel to alerter should be open")
     }
 
     fn on_alert_notification(&mut self, notification: ForkingNotification<H, D, MK::Signature>) {

--- a/src/rmc.rs
+++ b/src/rmc.rs
@@ -230,7 +230,7 @@ impl<'a, H: Signable + Hash + Eq + Clone + Debug, MK: MultiKeychain> ReliableMul
         );
         self.multisigned_hashes_tx
             .unbounded_send(multisigned.clone())
-            .expect("Channel should be open");
+            .expect("We own the the rx, so this can't fail");
         self.scheduler
             .add_task(Task::BroadcastMessage(Message::MultisignedHash(
                 multisigned.into_unchecked(),


### PR DESCRIPTION
We decided to panic when the receiving end of channel is closed. It is done by calling `.expect(...)` on send result.