### PR TITLE
EXPERIMENTAL: idle-aware spawner

### DIFF
--- a/src/testing/dag.rs
+++ b/src/testing/dag.rs
@@ -284,7 +284,6 @@ async fn ordering_random_dag_consistency_under_permutations() {
             let mut batch = run_consensus_on_dag(units.clone(), n_members).await;
             if batch != batch_on_sorted {
                 if batch_lists_consistent(&batch, &batch_on_sorted) {
-                    // there might be some timing issue here, we run it with more time
                     batch = run_consensus_on_dag(units.clone(), n_members).await;
                 }
                 if batch != batch_on_sorted {


### PR DESCRIPTION
Implementation of SpawnHandle with addidtional method `wait_idle`  that attempts to check if any spawned task called `waker` while it was executed. Should only be used paired with a single-threaded tasks runtime (tokio's default for tests). This PR also removes delay-driven code in some of our tests.