### PR TITLE
Change the Network trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-bft"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2018"
 authors = ["Cardinal Cryptography"]
 categories = ["algorithms", "data-structures", "cryptography", "database"]

--- a/README.md
+++ b/README.md
@@ -82,9 +82,7 @@ please refer to the [detailed version][reference-link].
   - The [Network][network-link] trait defines the functionality we expect from the network layer:
     ```rust
     pub trait Network<H: Hasher, D: Data, S: Encode + Decode>: Send {
-        type Error: Debug;
-        fn send(&self, data: NetworkData<H, D, S>, node: NodeIndex) -> Result<(), Self::Error>;
-        fn broadcast(&self, data: NetworkData<H, D, S>) -> Result<(), Self::Error>;
+        fn send(&self, data: NetworkData<H, D, S>, recipient: Recipient);
         async fn next_event(&mut self) -> Option<NetworkData<H, D, S>>;
     }
     ```

--- a/fuzz/src/fuzz.rs
+++ b/fuzz/src/fuzz.rs
@@ -1,6 +1,6 @@
 use aleph_bft::{
     DataIO as DataIOT, Index, KeyBox as KeyBoxT, MultiKeychain as MultiKeychainT, NetworkData,
-    OrderedBatch, PartialMultisignature as PartialMultisignatureT,
+    OrderedBatch, PartialMultisignature as PartialMultisignatureT, Recipient,
 };
 use futures::task::Poll;
 use parking_lot::Mutex;
@@ -241,15 +241,7 @@ impl<I: Iterator<Item = FuzzNetworkData> + Send, C: FnOnce() + Send>
     aleph_bft::Network<aleph_mock::Hasher64, Data, Signature, PartialMultisignature>
     for PlaybackNetwork<I, C>
 {
-    type Error = ();
-
-    fn send(&self, _: FuzzNetworkData, _: NodeIndex) -> std::result::Result<(), Self::Error> {
-        Ok(())
-    }
-
-    fn broadcast(&self, _: FuzzNetworkData) -> std::result::Result<(), Self::Error> {
-        Ok(())
-    }
+    fn send(&self, _: FuzzNetworkData, _: Recipient) {}
 
     async fn next_event(&mut self) -> Option<FuzzNetworkData> {
         match self.data.next() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ use crate::nodes::NodeMap;
 
 pub use config::{default_config, exponential_slowdown, Config, DelayConfig};
 pub use member::Member;
-pub use network::{Network, NetworkData};
+pub use network::{Network, NetworkData, Recipient};
 pub use nodes::{NodeCount, NodeIndex};
 
 mod alerts;

--- a/src/testing/byzantine.rs
+++ b/src/testing/byzantine.rs
@@ -13,8 +13,8 @@ use crate::{
         KeyBox, Network, NetworkData, Spawner,
     },
     units::{ControlHash, FullUnit, PreUnit, SignedUnit, UnitCoord},
-    Hasher, Network as NetworkT, NetworkData as NetworkDataT, NodeCount, NodeIndex, Round,
-    SessionId, SpawnHandle,
+    Hasher, Network as NetworkT, NetworkData as NetworkDataT, NodeCount, NodeIndex, Recipient,
+    Round, SessionId, SpawnHandle,
 };
 
 use crate::member::UnitMessage::NewUnit;
@@ -87,7 +87,7 @@ impl<'a> MaliciousMember<'a> {
 
     fn send_legit_unit(&mut self, su: SignedUnit<'a, Hasher64, Data, KeyBox>) {
         let message = Self::unit_to_data(su);
-        let _ = self.network.broadcast(message);
+        self.network.send(message, Recipient::Everyone);
     }
 
     fn send_two_variants(
@@ -102,9 +102,11 @@ impl<'a> MaliciousMember<'a> {
         for ix in 0..self.n_members.0 {
             let node_ix = NodeIndex(ix);
             let _ = if ix % 2 == 0 {
-                self.network.send(message0.clone(), node_ix)
+                self.network
+                    .send(message0.clone(), Recipient::Node(node_ix))
             } else {
-                self.network.send(message1.clone(), node_ix)
+                self.network
+                    .send(message1.clone(), Recipient::Node(node_ix))
             };
         }
     }


### PR DESCRIPTION
Remove the errors and coalesce the two methods into one, exposing the
Recipient enum as a better interface.