### PR TITLE
Fixed bug with wrong control hash of self unit.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ codec = { package = "parity-scale-codec", version = "2", default-features = fals
 parking_lot = "0.11"
 
 [dev-dependencies]
-assert_matches = "1.5"
 sha3 = "0.9.1"
 unsigned-varint = { version = "0.7.0", features = ["futures", "asynchronous_codec"] }
 tokio = { version = "1.6.1", features = ["macros", "rt", "rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ codec = { package = "parity-scale-codec", version = "2", default-features = fals
 parking_lot = "0.11"
 
 [dev-dependencies]
+assert_matches = "1.5"
 sha3 = "0.9.1"
 unsigned-varint = { version = "0.7.0", features = ["futures", "asynchronous_codec"] }
 tokio = { version = "1.6.1", features = ["macros", "rt", "rt-multi-thread"] }

--- a/src/creator.rs
+++ b/src/creator.rs
@@ -74,11 +74,12 @@ impl<H: Hasher> Creator<H> {
         };
 
         let control_hash = ControlHash::new(&parents);
+        let parent_hashes: Vec<H::Hash> = parents.into_iter().flatten().collect();
 
         let new_preunit = PreUnit::new(self.node_ix, round, control_hash);
         trace!(target: "AlephBFT-creator", "{:?} Created a new unit {:?} at round {:?}.", self.node_ix, new_preunit, self.current_round);
         self.new_units_tx
-            .unbounded_send(NotificationOut::CreatedPreUnit(new_preunit))
+            .unbounded_send(NotificationOut::CreatedPreUnit(new_preunit, parent_hashes))
             .expect("Notification channel should be open");
 
         self.current_round += 1;

--- a/src/member.rs
+++ b/src/member.rs
@@ -192,6 +192,9 @@ where
         let hash = full_unit.hash();
         let signed_unit = Signed::sign(full_unit, self.keybox).await;
         self.store.add_unit(signed_unit, false);
+        // We add the parents to store here to make sure that our node will be able to answer parents queries for this unit.
+        // In extremely rare cases it can happen that this node, after adding this unit to the Terminal will trigger a
+        // WrongControlHash notification. This is still fine as the member will answer it without sending a request outside.
         self.store.add_parents(hash, parent_hashes);
         let curr_time = time::Instant::now();
         let task = ScheduledTask::new(Task::UnitMulticast(hash, 0), curr_time);
@@ -319,8 +322,7 @@ where
     fn on_wrong_control_hash(&mut self, u_hash: H::Hash) {
         trace!(target: "AlephBFT-member", "{:?} Dealing with wrong control hash notification {:?}.", self.index(), u_hash);
         if let Some(p_hashes) = self.store.get_parents(u_hash) {
-            // We have the parents by some strange reason (someone sent us parents
-            // without us requesting them).
+            // We have the parents -- most likely this is a unit created by us.
             let p_hashes = p_hashes.clone();
             trace!(target: "AlephBFT-member", "{:?} We have the parents for {:?} even though we did not request them.", self.index(), u_hash);
             self.send_consensus_notification(NotificationIn::UnitParents(u_hash, p_hashes));

--- a/src/testing/consensus.rs
+++ b/src/testing/consensus.rs
@@ -56,14 +56,6 @@ async fn agree_on_first_batch() {
     for node_ix in 1..n_members {
         assert_eq!(batches[0], batches[node_ix]);
     }
-
-    exits.into_iter().for_each(|tx| {
-        let _ = tx.send(());
-    });
-
-    for handle in &mut handles {
-        handle.await.expect("All nodes are honest.");
-    }
 }
 
 #[tokio::test]

--- a/src/testing/mock.rs
+++ b/src/testing/mock.rs
@@ -133,7 +133,7 @@ impl HonestHub {
 
     fn on_notification(&mut self, node_ix: NodeIndex, ntfct: NotificationOut<Hasher64>) {
         match ntfct {
-            NotificationOut::CreatedPreUnit(pu) => {
+            NotificationOut::CreatedPreUnit(pu, _parent_hashes) => {
                 let hash = pu.using_encoded(Hasher64::hash);
                 let u = Unit::new(pu, hash);
                 let coord = UnitCoord::new(u.round(), u.creator());


### PR DESCRIPTION
The issue was that in a certain very unlucky situations involving forks it could happen that an honest unit creator would not be able to answer a parents request for its own unit (it wouldn't be able to decode the control hash). 

Very roughly speaking the reason for that was that in the terminal we only remember one unit variant (=fork) in the `unit_by_coord` map (Terminal), and more specifically (prior to this fix) this was always the most recent variant we received. This map is used when trying to decode parents -- if the parents units from this map do not agree with the control hash, a `WrongControlHash` notification is sent. It could happen, that a unit U was created, referring to a parent V1, and then before this unit U was added to the DAG, another variant V2 could be added to DAG (after a successful alert), replacing V1 in the `unit_by_coord` map, which would then result in a `WrongControlHash` notification for U and consequently in a serious issue -- none of the members would be able to decode the parents. The fix for this is quite easy: we just add a field `parent_hashes` to the CreatedPreUnit notification that is sent out by the Creator. This way, we can note in the store the parents of our units, so that even if it happens that Terminal reports WrongControlHash for our unit, we will have the parents in our store and will successfully decode them.

This bug fix does not have any accompanying test -- after adding another field to the notification this bug cannot be recreated, because by construction the parents are explicitly provided, so they cannot be missing anymore :) Still, I have locally run the `small_byzantine_one_forker` test 1000 times, with 0 failures, whereas previously it froze roughly 1 in 50 times.