### PR TITLE
A0-231: Two improvements of requests in member

### DIFF
--- a/src/member.rs
+++ b/src/member.rs
@@ -85,7 +85,7 @@ pub(crate) enum NotificationOut<H: Hasher> {
 
 #[derive(Eq, PartialEq)]
 enum Task<H: Hasher> {
-    // Request the unit with the given hash.
+    // Request the unit with the given (creator, round) coordinates.
     CoordRequest(UnitCoord),
     // Request parents of the unit with the given hash.
     ParentsRequest(H::Hash),


### PR DESCRIPTION
Two improvements of requests in member.

* when multiple units trigger a "missing unit" notification for their common parent, multiple tasks requesting the unit with an appropriate coordinates were created. Now we have at most one task for every (creator, round) coordinate.
* when we need parents of the unit with a given hash, we used to periodically send requests to random peers. This PR optimizes it by always sending the first request for a given hash to the peer who created the corresponding unit (who is most likely to own ).

EDIT: currently we also use the latter improvement in the case when we need a unit with given coordinates 