### PR TITLE
FIX: towards graceful exit - creator.rs was calling a possibly "finished" stream

### DIFF
--- a/src/creator.rs
+++ b/src/creator.rs
@@ -136,6 +136,7 @@ impl<H: Hasher> Creator<H> {
                 self.add_unit(u.round(), u.creator(), u.hash());
             } else {
                 warn!(target: "AlephBFT-creator", "{:?} get error as result from channel with parents.", self.node_ix);
+                return;
             }
         }
     }


### PR DESCRIPTION
- FIX: parents_rx in creator.rs was called multiple times after it returned None (calling next() after stream is empty) blocking creator from gracefully exiting.
- removed "as usize" calls from creator