### PR TITLE
A0-249 + A0-250: Node crash recovery

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-bft"
-version = "0.5.6"
+version = "0.6.0"
 edition = "2018"
 authors = ["Cardinal Cryptography"]
 categories = ["algorithms", "data-structures", "cryptography", "database"]

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -2,7 +2,7 @@ use futures::{
     channel::{mpsc, oneshot},
     FutureExt,
 };
-use log::{debug, info};
+use log::{debug, error, info};
 
 use crate::{
     config::Config,
@@ -10,7 +10,7 @@ use crate::{
     extender::Extender,
     runway::{NotificationIn, NotificationOut},
     terminal::Terminal,
-    Hasher, OrderedBatch, Receiver, Sender, SpawnHandle,
+    Hasher, OrderedBatch, Receiver, Round, Sender, SpawnHandle,
 };
 
 pub(crate) async fn run<H: Hasher + 'static>(
@@ -19,6 +19,7 @@ pub(crate) async fn run<H: Hasher + 'static>(
     outgoing_notifications: Sender<NotificationOut<H>>,
     ordered_batch_tx: Sender<OrderedBatch<H::Hash>>,
     spawn_handle: impl SpawnHandle,
+    starting_round: oneshot::Receiver<Round>,
     mut exit: oneshot::Receiver<()>,
 ) {
     info!(target: "AlephBFT", "{:?} Starting all services...", conf.node_ix);
@@ -41,7 +42,12 @@ pub(crate) async fn run<H: Hasher + 'static>(
     let (creator_exit, exit_rx) = oneshot::channel();
     let mut creator_handle = spawn_handle
         .spawn_essential("consensus/creator", async move {
-            creator.create(0, exit_rx).await
+            match starting_round.await {
+                Ok(round) => creator.create(round, exit_rx).await,
+                Err(e) => {
+                    error!(target: "AlephBFT-creator", "Starting round not provided: {}", e);
+                }
+            }
         })
         .fuse();
 

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -40,10 +40,9 @@ pub(crate) async fn run<H: Hasher + 'static>(
 
     let (creator_exit, exit_rx) = oneshot::channel();
     let mut creator_handle = spawn_handle
-        .spawn_essential(
-            "consensus/creator",
-            async move { creator.create(exit_rx).await },
-        )
+        .spawn_essential("consensus/creator", async move {
+            creator.create(0, exit_rx).await
+        })
         .fuse();
 
     let mut terminal = Terminal::new(conf.node_ix, incoming_notifications, outgoing_notifications);

--- a/src/creator.rs
+++ b/src/creator.rs
@@ -5,9 +5,12 @@ use crate::{
     units::{ControlHash, PreUnit, Unit},
     Hasher, Receiver, Round, Sender,
 };
-use futures::{channel::oneshot, FutureExt, StreamExt};
+use futures::{
+    channel::{mpsc::TrySendError, oneshot},
+    FutureExt, StreamExt,
+};
 use futures_timer::Delay;
-use log::{info, trace, warn};
+use log::{error, info, trace, warn};
 use std::time::Duration;
 
 /// A process responsible for creating new units. It receives all the units added locally to the Dag
@@ -63,7 +66,7 @@ impl<H: Hasher> Creator<H> {
         }
     }
 
-    fn create_unit(&mut self, round: Round) {
+    fn create_unit(&mut self, round: Round) -> Result<(), TrySendError<NotificationOut<H>>> {
         let parents = {
             if round == 0 {
                 NodeMap::new_with_len(self.n_members)
@@ -77,11 +80,10 @@ impl<H: Hasher> Creator<H> {
 
         let new_preunit = PreUnit::new(self.node_ix, round, control_hash);
         trace!(target: "AlephBFT-creator", "{:?} Created a new unit {:?} at round {:?}.", self.node_ix, new_preunit, round);
-        self.new_units_tx
-            .unbounded_send(NotificationOut::CreatedPreUnit(new_preunit, parent_hashes))
-            .expect("Notification channel should be open");
-
+        let notification = NotificationOut::CreatedPreUnit(new_preunit, parent_hashes);
+        self.new_units_tx.unbounded_send(notification)?;
         self.init_round(round + 1);
+        Ok(())
     }
 
     fn add_unit(&mut self, round: Round, pid: NodeIndex, hash: H::Hash) {
@@ -129,7 +131,8 @@ impl<H: Hasher> Creator<H> {
         // Additionally, our unit from previous round must be available.
         let threshold = (self.n_members * 2) / 3 + NodeCount(1);
 
-        while self.n_candidates_by_round[prev_round_index] < threshold
+        while self.n_candidates_by_round.len() <= prev_round_index
+            || self.n_candidates_by_round[prev_round_index] < threshold
             || self.candidates_by_round[prev_round_index][self.node_ix].is_none()
         {
             if let Some(u) = self.parents_rx.next().await {
@@ -141,8 +144,9 @@ impl<H: Hasher> Creator<H> {
         }
     }
 
-    pub(crate) async fn create(&mut self, mut exit: oneshot::Receiver<()>) {
-        for round in 0..self.max_round {
+    pub(crate) async fn create(&mut self, starting_round: Round, mut exit: oneshot::Receiver<()>) {
+        log::debug!(target: "AlephBFT-creator", "Creator starting from round {}", starting_round);
+        for round in starting_round..self.max_round {
             let mut delay = Delay::new(Duration::from_secs(30 * 60)).fuse();
             loop {
                 futures::select! {
@@ -159,7 +163,10 @@ impl<H: Hasher> Creator<H> {
                     }
                 }
             }
-            self.create_unit(round);
+            if let Err(e) = self.create_unit(round) {
+                error!(target: "AlephBFT-creator", "{:?} Unable to broadcast new unit: {}", self.node_ix, e);
+                return;
+            }
         }
         warn!(target: "AlephBFT-creator", "{:?} Maximum round reached. Not creating another unit.", self.node_ix);
     }
@@ -268,7 +275,7 @@ mod tests {
 
             let (killer, exit) = oneshot::channel::<()>();
 
-            let handle = tokio::spawn(async move { creator.create(exit).await });
+            let handle = tokio::spawn(async move { creator.create(0, exit).await });
 
             killers.push(killer);
             handles.push(handle);
@@ -302,6 +309,84 @@ mod tests {
         assert_eq!(
             test_controller.n_candidates_by_round[rounds - 1],
             test_controller.n_members
+        );
+        finish(killers, handles).await;
+    }
+    // Crash recovery test
+    // This test starts with 7 creators. After 25 rounds 2 of them are killed and start again after rest will get to round 50.
+    // Then it is checked if 5 creators achieve round 75 and rest round 73.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+    async fn crashed_creators_should_create_dag() {
+        let n_members: usize = 7;
+        let rounds: usize = 25;
+        let n_fallen_members: usize = 0;
+        let max_units: usize = n_members * rounds;
+
+        let (mut test_controller, mut killers, mut handles, to_test_controller) =
+            start(n_members, n_fallen_members, max_units).await;
+        test_controller.control().await;
+
+        let n_fallen_members = 2;
+        let rounds = 50;
+        let mut last_indexes: Vec<usize> = vec![];
+        for node_ix in 0..n_fallen_members {
+            test_controller.units_out.pop().unwrap();
+            killers.pop().unwrap().send(()).unwrap();
+            handles.pop().unwrap();
+
+            let last_index: usize = test_controller
+                .candidates_by_round
+                .iter()
+                .enumerate()
+                .filter(|(_, val)| val[node_ix.into()].is_some())
+                .max_by_key(|&(i, _)| i)
+                .unwrap()
+                .0;
+            last_indexes.push(last_index);
+        }
+
+        let max_units = (n_members - n_fallen_members) * rounds
+            + last_indexes.iter().sum::<usize>()
+            + n_fallen_members;
+        test_controller.max_units = max_units;
+        test_controller.control().await;
+
+        for (mut node_ix, _last_index) in last_indexes.into_iter().enumerate() {
+            node_ix += 5;
+            let (units_out, from_test_controller) = mpsc::unbounded();
+
+            let mut creator = Creator::new(
+                gen_config(node_ix.into(), n_members.into()),
+                from_test_controller,
+                to_test_controller.clone(),
+            );
+            creator.n_candidates_by_round = test_controller.n_candidates_by_round.clone();
+            creator.candidates_by_round = test_controller.candidates_by_round.clone();
+
+            test_controller.units_out.push(units_out);
+
+            let (killer, exit) = oneshot::channel::<()>();
+
+            let handle = tokio::spawn(async move { creator.create(25, exit).await });
+
+            killers.push(killer);
+            handles.push(handle);
+        }
+
+        let rounds = 75;
+        let max_units = n_members * rounds - n_fallen_members * 2;
+        test_controller.max_units = max_units;
+        test_controller.control().await;
+
+        for round in 0..(rounds - 2) {
+            assert_eq!(
+                test_controller.n_candidates_by_round[round],
+                n_members.into()
+            );
+        }
+        assert!(
+            test_controller.n_candidates_by_round[rounds - 1]
+                >= (n_members - n_fallen_members).into()
         );
         finish(killers, handles).await;
     }
@@ -340,7 +425,7 @@ mod tests {
 
             let (killer, exit) = oneshot::channel::<()>();
 
-            let handle = tokio::spawn(async move { creator.create(exit).await });
+            let handle = tokio::spawn(async move { creator.create(0, exit).await });
 
             killers.push(killer);
             handles.push(handle);

--- a/src/creator.rs
+++ b/src/creator.rs
@@ -171,15 +171,14 @@ impl<H: Hasher> Creator<H> {
                         self.exiting = true;
                     }
                 }
+                if self.exiting {
+                    info!(target: "AlephBFT-creator", "{:?} Creator decided to exit.", self.node_ix);
+                    return;
+                }
             }
             if let Err(e) = self.create_unit(round) {
                 error!(target: "AlephBFT-creator", "{:?} Unable to broadcast new unit: {}", self.node_ix, e);
                 return;
-            }
-
-            if self.exiting {
-                info!(target: "AlephBFT-creator", "{:?} Creator decided to exit.", self.node_ix);
-                break;
             }
         }
         warn!(target: "AlephBFT-creator", "{:?} Maximum round reached. Not creating another unit.", self.node_ix);
@@ -289,7 +288,7 @@ mod tests {
 
             let (killer, i) = oneshot::channel::<()>();
 
-            let handle = tokio::spawn(async move { creator.create(0, exit).await });
+            let handle = tokio::spawn(async move { creator.create(0, i).await });
 
             killers.push(killer);
             handles.push(handle);

--- a/src/member.rs
+++ b/src/member.rs
@@ -360,7 +360,6 @@ where
                         Request::Coord(coord) => { self.not_resolved_coords.remove(&coord); },
                         Request::Parents(u_hash) => { self.not_resolved_parents.remove(&u_hash); },
                         Request::NewestUnit(_) => {
-                            // TODO: ensure that the salt is right?
                             self.newest_unit_resolved = true;
                         }
                     },

--- a/src/member.rs
+++ b/src/member.rs
@@ -359,7 +359,7 @@ where
                     Some(request) => match request {
                         Request::Coord(coord) => { self.not_resolved_coords.remove(&coord); },
                         Request::Parents(u_hash) => { self.not_resolved_parents.remove(&u_hash); },
-                        Request::NewestUnit(_salt) => {
+                        Request::NewestUnit(_) => {
                             // TODO: ensure that the salt is right?
                             self.newest_unit_resolved = true;
                         }

--- a/src/member.rs
+++ b/src/member.rs
@@ -4,8 +4,8 @@ use crate::{
     runway::{self, Request, Response, RunwayIO, RunwayNotificationIn, RunwayNotificationOut},
     signed::Signature,
     units::{UncheckedSignedUnit, UnitCoord},
-    Data, DataIO, Hasher, MultiKeychain, Network, NodeCount, NodeIndex, Receiver, Sender,
-    SpawnHandle,
+    Data, DataIO, Hasher, MultiKeychain, Network, NodeCount, NodeIndex, Receiver, Sender, Signable,
+    SpawnHandle, UncheckedSigned,
 };
 use codec::{Decode, Encode};
 use futures::{
@@ -24,6 +24,28 @@ use std::{
     time,
 };
 
+#[derive(Debug, Encode, Decode, Clone)]
+pub(crate) struct NewestUnitResponse<H: Hasher, D: Data, S: Signature> {
+    pub(crate) requester: NodeIndex,
+    pub(crate) responder: NodeIndex,
+    pub(crate) unit: Option<UncheckedSignedUnit<H, D, S>>,
+    pub(crate) salt: u64,
+}
+
+impl<H: Hasher, D: Data, S: Signature> Signable for NewestUnitResponse<H, D, S> {
+    type Hash = Vec<u8>;
+
+    fn hash(&self) -> Self::Hash {
+        self.encode()
+    }
+}
+
+impl<H: Hasher, D: Data, S: Signature> crate::Index for NewestUnitResponse<H, D, S> {
+    fn index(&self) -> NodeIndex {
+        self.responder
+    }
+}
+
 /// A message concerning units, either about new units or some requests for them.
 #[derive(Debug, Encode, Decode, Clone)]
 pub(crate) enum UnitMessage<H: Hasher, D: Data, S: Signature> {
@@ -37,6 +59,10 @@ pub(crate) enum UnitMessage<H: Hasher, D: Data, S: Signature> {
     RequestParents(NodeIndex, H::Hash),
     /// Response to a request for a full list of parents.
     ResponseParents(H::Hash, Vec<UncheckedSignedUnit<H, D, S>>),
+    /// Request by a node for the newest unit created by them, together with a u64 salt
+    RequestNewest(NodeIndex, u64),
+    /// Response to RequestNewest: (our index, maybe unit, salt) signed by us
+    ResponseNewest(UncheckedSigned<NewestUnitResponse<H, D, S>, S>),
 }
 
 impl<H: Hasher, D: Data, S: Signature> UnitMessage<H, D, S> {
@@ -47,6 +73,13 @@ impl<H: Hasher, D: Data, S: Signature> UnitMessage<H, D, S> {
             Self::ResponseCoord(uu) => vec![uu.as_signable().data().clone()],
             Self::RequestParents(_, _) => Vec::new(),
             Self::ResponseParents(_, units) => units
+                .iter()
+                .map(|uu| uu.as_signable().data().clone())
+                .collect(),
+            UnitMessage::RequestNewest(_, _) => Vec::new(),
+            UnitMessage::ResponseNewest(response) => response
+                .as_signable()
+                .unit
                 .iter()
                 .map(|uu| uu.as_signable().data().clone())
                 .collect(),
@@ -62,6 +95,8 @@ enum Task<H: Hasher, D: Data, S: Signature> {
     ParentsRequest(H::Hash, Recipient),
     // Broadcast the given unit.
     UnitMulticast(UncheckedSignedUnit<H, D, S>),
+    // Request the newest unit created by node itself.
+    RequestNewest(u64),
 }
 
 #[derive(Eq, PartialEq)]
@@ -105,6 +140,7 @@ where
     task_queue: BinaryHeap<ScheduledTask<H, D, S>>,
     not_resolved_parents: HashSet<H::Hash>,
     not_resolved_coords: HashSet<UnitCoord>,
+    newest_unit_resolved: bool,
     n_members: NodeCount,
     unit_messages_for_network: Sender<(UnitMessage<H, D, S>, Recipient)>,
     unit_messages_from_network: Receiver<UnitMessage<H, D, S>>,
@@ -133,6 +169,7 @@ where
             task_queue: BinaryHeap::new(),
             not_resolved_parents: HashSet::new(),
             not_resolved_coords: HashSet::new(),
+            newest_unit_resolved: false,
             n_members,
             unit_messages_for_network,
             unit_messages_from_network,
@@ -165,6 +202,13 @@ where
         }
         let curr_time = time::Instant::now();
         let task = ScheduledTask::new(Task::ParentsRequest(u_hash, recipient), curr_time);
+        self.task_queue.push(task);
+        self.trigger_tasks();
+    }
+
+    fn on_request_newest(&mut self, salt: u64) {
+        let curr_time = time::Instant::now();
+        let task = ScheduledTask::new(Task::RequestNewest(salt), curr_time);
         self.task_queue.push(task);
         self.trigger_tasks();
     }
@@ -240,6 +284,14 @@ where
                 let preferred_recipient = Recipient::Everyone;
                 (message, preferred_recipient)
             }
+            Task::RequestNewest(salt) => {
+                if self.newest_unit_resolved {
+                    return None;
+                }
+                let message = UnitMessage::RequestNewest(self.index(), *salt);
+                let preferred_recipient = Recipient::Everyone;
+                (message, preferred_recipient)
+            }
         };
         let (recipient, delay) = match preferred_recipient {
             Recipient::Everyone => (
@@ -265,17 +317,23 @@ where
         match message {
             RunwayNotificationOut::NewUnit(u) => self.on_create(u),
             RunwayNotificationOut::Request(request, recipient) => match request {
-                Request::RequestCoord(coord) => self.on_request_coord(coord),
-                Request::RequestParents(u_hash) => self.on_request_parents(u_hash, recipient),
+                Request::Coord(coord) => self.on_request_coord(coord),
+                Request::Parents(u_hash) => self.on_request_parents(u_hash, recipient),
+                Request::NewestUnit(salt) => self.on_request_newest(salt),
             },
             RunwayNotificationOut::Response(response, recipient) => match response {
-                Response::ResponseCoord(u) => {
+                Response::Coord(u) => {
                     let message = UnitMessage::ResponseCoord(u);
                     self.send_unit_message(message, Recipient::Node(recipient))
                 }
-                Response::ResponseParents(u_hash, parents) => {
+                Response::Parents(u_hash, parents) => {
                     let message = UnitMessage::ResponseParents(u_hash, parents);
                     self.send_unit_message(message, Recipient::Node(recipient))
+                }
+                Response::NewestUnit(response) => {
+                    let requester = response.as_signable().requester;
+                    let message = UnitMessage::ResponseNewest(response);
+                    self.send_unit_message(message, Recipient::Node(requester))
                 }
             },
         }
@@ -299,8 +357,12 @@ where
 
                 event = self.resolved_requests.next() => match event {
                     Some(request) => match request {
-                        Request::RequestCoord(coord) => { self.not_resolved_coords.remove(&coord); },
-                        Request::RequestParents(u_hash) => { self.not_resolved_parents.remove(&u_hash); },
+                        Request::Coord(coord) => { self.not_resolved_coords.remove(&coord); },
+                        Request::Parents(u_hash) => { self.not_resolved_parents.remove(&u_hash); },
+                        Request::NewestUnit(_salt) => {
+                            // TODO: ensure that the salt is right?
+                            self.newest_unit_resolved = true;
+                        }
                     },
                     None => {
                         error!(target: "AlephBFT-member", "{:?} Resolved-requests stream from Runway closed.", self.index());

--- a/src/runway.rs
+++ b/src/runway.rs
@@ -248,7 +248,7 @@ where
 
     fn resolve_missing_coord(&mut self, coord: &UnitCoord) {
         if self.missing_coords.remove(coord) {
-            self.send_resolved_request_notification(Request::RequestCoord(*coord));
+            self.send_resolved_request_notification(Request::Coord(*coord));
         }
     }
 
@@ -366,7 +366,7 @@ where
         if let Some(su) = maybe_su {
             trace!(target: "AlephBFT-runway", "{:?} Answering fetch request for coord {:?} from {:?}.", self.index(), coord, node_id);
             self.send_message_for_network(RunwayNotificationOut::Response(
-                Response::ResponseCoord(su.into()),
+                Response::Coord(su.into()),
                 node_id,
             ));
         } else {
@@ -395,7 +395,7 @@ where
                 }
             }
             self.send_message_for_network(RunwayNotificationOut::Response(
-                Response::ResponseParents(u_hash, full_units),
+                Response::Parents(u_hash, full_units),
                 node_id,
             ));
         } else {
@@ -571,7 +571,7 @@ where
 
     fn resolve_missing_parents(&mut self, u_hash: &H::Hash) {
         if self.missing_parents.remove(u_hash) {
-            self.send_resolved_request_notification(Request::RequestParents(*u_hash));
+            self.send_resolved_request_notification(Request::Parents(*u_hash));
         }
     }
 
@@ -634,7 +634,7 @@ where
         for coord in coords {
             if self.missing_coords.insert(coord) {
                 self.send_message_for_network(RunwayNotificationOut::Request(
-                    Request::RequestCoord(coord),
+                    Request::Coord(coord),
                     Recipient::Node(coord.creator()),
                 ));
             }
@@ -662,7 +662,7 @@ where
             };
             if self.missing_parents.insert(u_hash) {
                 self.send_message_for_network(RunwayNotificationOut::Request(
-                    Request::RequestParents(u_hash),
+                    Request::Parents(u_hash),
                     recipient,
                 ));
             }

--- a/src/runway.rs
+++ b/src/runway.rs
@@ -19,6 +19,8 @@ use futures::{
 };
 use log::{debug, error, info, trace, warn};
 use std::time::Duration;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 
 /// Type for incoming notifications: Runway to Consensus.
 #[derive(Clone, PartialEq)]
@@ -850,6 +852,12 @@ pub(crate) async fn run<H, D, MK, DP, SH>(
 
     let index = config.node_ix;
 
+    let salt = {
+        let mut hasher = DefaultHasher::new();
+        std::time::Instant::now().hash(&mut hasher);
+        hasher.finish()
+    };
+
     let runway_config = RunwayConfig {
         keychain: &keychain,
         data_io,
@@ -866,7 +874,7 @@ pub(crate) async fn run<H, D, MK, DP, SH>(
         session_id: config.session_id,
         n_members: config.n_members,
         max_round: config.max_round,
-        salt: 0,
+        salt
     };
     let (runway_exit, exit_stream) = oneshot::channel();
     let runway = Runway::new(runway_config);

--- a/src/runway.rs
+++ b/src/runway.rs
@@ -3,14 +3,14 @@ use std::{collections::HashSet, convert::TryFrom};
 use crate::{
     alerts::{self, Alert, AlertConfig, AlertMessage, ForkProof, ForkingNotification},
     consensus,
-    member::UnitMessage,
+    member::{NewestUnitResponse, UnitMessage},
     network::Recipient,
     nodes::NodeMap,
     units::{
         ControlHash, FullUnit, PreUnit, SignedUnit, UncheckedSignedUnit, Unit, UnitCoord, UnitStore,
     },
     Config, Data, DataIO, Hasher, Index, MultiKeychain, NodeCount, NodeIndex, OrderedBatch,
-    Receiver, Round, Sender, SessionId, Signature, Signed, SpawnHandle,
+    Receiver, Round, Sender, SessionId, Signature, Signed, SpawnHandle, UncheckedSigned,
 };
 use futures::{
     channel::{mpsc, oneshot},
@@ -18,6 +18,7 @@ use futures::{
     pin_mut, FutureExt, StreamExt,
 };
 use log::{debug, error, info, trace, warn};
+use std::time::Duration;
 
 /// Type for incoming notifications: Runway to Consensus.
 #[derive(Clone, PartialEq)]
@@ -45,13 +46,15 @@ pub(crate) enum NotificationOut<H: Hasher> {
 }
 
 pub(crate) enum Request<H: Hasher> {
-    RequestCoord(UnitCoord),
-    RequestParents(H::Hash),
+    Coord(UnitCoord),
+    Parents(H::Hash),
+    NewestUnit(u64),
 }
 
 pub(crate) enum Response<H: Hasher, D: Data, S: Signature> {
-    ResponseCoord(UncheckedSignedUnit<H, D, S>),
-    ResponseParents(H::Hash, Vec<UncheckedSignedUnit<H, D, S>>),
+    Coord(UncheckedSignedUnit<H, D, S>),
+    Parents(H::Hash, Vec<UncheckedSignedUnit<H, D, S>>),
+    NewestUnit(UncheckedSigned<NewestUnitResponse<H, D, S>, S>),
 }
 
 pub(crate) enum RunwayNotificationOut<H: Hasher, D: Data, S: Signature> {
@@ -75,16 +78,20 @@ impl<H: Hasher, D: Data, S: Signature> TryFrom<UnitMessage<H, D, S>>
         let result = match message {
             UnitMessage::NewUnit(u) => RunwayNotificationIn::NewUnit(u),
             UnitMessage::RequestCoord(node_id, coord) => {
-                RunwayNotificationIn::Request(Request::RequestCoord(coord), node_id)
+                RunwayNotificationIn::Request(Request::Coord(coord), node_id)
             }
             UnitMessage::RequestParents(node_id, u_hash) => {
-                RunwayNotificationIn::Request(Request::RequestParents(u_hash), node_id)
+                RunwayNotificationIn::Request(Request::Parents(u_hash), node_id)
             }
-            UnitMessage::ResponseCoord(u) => {
-                RunwayNotificationIn::Response(Response::ResponseCoord(u))
-            }
+            UnitMessage::ResponseCoord(u) => RunwayNotificationIn::Response(Response::Coord(u)),
             UnitMessage::ResponseParents(u_hash, parents) => {
-                RunwayNotificationIn::Response(Response::ResponseParents(u_hash, parents))
+                RunwayNotificationIn::Response(Response::Parents(u_hash, parents))
+            }
+            UnitMessage::RequestNewest(node_id, salt) => {
+                RunwayNotificationIn::Request(Request::NewestUnit(salt), node_id)
+            }
+            UnitMessage::ResponseNewest(response) => {
+                RunwayNotificationIn::Response(Response::NewestUnit(response))
             }
         };
         Ok(result)
@@ -115,6 +122,11 @@ where
     rx_consensus: Receiver<NotificationOut<H>>,
     ordered_batch_rx: Receiver<Vec<H::Hash>>,
     data_io: DP,
+    after_catch_up_delay: bool,
+    starting_round_sender: Option<oneshot::Sender<Round>>,
+    starting_round_value: Round,
+    newest_unit_responders: HashSet<NodeIndex>,
+    salt: u64,
 }
 
 struct RunwayConfig<'a, H: Hasher, D: Data, DP: DataIO<D>, MK: MultiKeychain> {
@@ -132,6 +144,8 @@ struct RunwayConfig<'a, H: Hasher, D: Data, DP: DataIO<D>, MK: MultiKeychain> {
     unit_messages_for_network: Sender<RunwayNotificationOut<H, D, MK::Signature>>,
     ordered_batch_rx: Receiver<Vec<H::Hash>>,
     resolved_requests: Sender<Request<H>>,
+    starting_round_sender: oneshot::Sender<Round>,
+    salt: u64,
 }
 
 impl<'a, H, D, MK, DP> Runway<'a, H, D, MK, DP>
@@ -162,9 +176,14 @@ where
             rx_consensus: config.rx_consensus,
             ordered_batch_rx: config.ordered_batch_rx,
             data_io: config.data_io,
+            after_catch_up_delay: false,
+            starting_round_sender: Some(config.starting_round_sender),
+            starting_round_value: 0,
             node_ix: config.node_ix,
             session_id: config.session_id,
             n_members: config.n_members,
+            newest_unit_responders: HashSet::new(),
+            salt: config.salt,
         }
     }
 
@@ -172,30 +191,39 @@ where
         self.node_ix
     }
 
-    fn on_unit_message(&mut self, message: RunwayNotificationIn<H, D, MK::Signature>) {
+    async fn on_unit_message(&mut self, message: RunwayNotificationIn<H, D, MK::Signature>) {
         match message {
             RunwayNotificationIn::NewUnit(u) => {
                 trace!(target: "AlephBFT-runway", "{:?} New unit received {:?}.", self.index(), &u);
                 self.on_unit_received(u, false)
             }
             RunwayNotificationIn::Request(request, node_id) => match request {
-                Request::RequestCoord(coord) => {
+                Request::Coord(coord) => {
                     trace!(target: "AlephBFT-runway", "{:?} Coords request received {:?}.", self.index(), coord);
                     self.on_request_coord(node_id, coord)
                 }
-                Request::RequestParents(u_hash) => {
+                Request::Parents(u_hash) => {
                     trace!(target: "AlephBFT-runway", "{:?} Parents request received {:?}.", self.index(), u_hash);
                     self.on_request_parents(node_id, u_hash)
                 }
+                Request::NewestUnit(salt) => {
+                    trace!(target: "AlephBFT-runway", "{:?} Newest unit request received {:?}.", self.index(), salt);
+                    self.on_request_newest(node_id, salt).await
+                }
             },
             RunwayNotificationIn::Response(res) => match res {
-                Response::ResponseCoord(u) => {
+                Response::Coord(u) => {
                     trace!(target: "AlephBFT-runway", "{:?} Fetch response received {:?}.", self.index(), &u);
                     self.on_unit_received(u, false)
                 }
-                Response::ResponseParents(u_hash, parents) => {
+                Response::Parents(u_hash, parents) => {
                     trace!(target: "AlephBFT-runway", "{:?} Response parents received {:?}.", self.index(), u_hash);
                     self.on_parents_response(u_hash, parents)
+                }
+                Response::NewestUnit(response) => {
+                    let salt = response.as_signable().salt;
+                    trace!(target: "AlephBFT-runway", "{:?} Response parents received {:?}.", self.index(), salt);
+                    self.on_newest_response(response);
                 }
             },
         }
@@ -215,7 +243,7 @@ where
     fn resolve_missing_coord(&mut self, coord: &UnitCoord) {
         if self.missing_coords.remove(coord) {
             self.resolved_requests
-                .unbounded_send(Request::RequestCoord(*coord))
+                .unbounded_send(Request::Coord(*coord))
                 .expect("resolved_requests channel should be open")
         }
     }
@@ -334,7 +362,7 @@ where
             trace!(target: "AlephBFT-runway", "{:?} Answering fetch request for coord {:?} from {:?}.", self.index(), coord, node_id);
             self.unit_messages_for_network
                 .unbounded_send(RunwayNotificationOut::Response(
-                    Response::ResponseCoord(su.into()),
+                    Response::Coord(su.into()),
                     node_id,
                 ))
                 .expect("unit_messages_for_network channel should be open")
@@ -365,12 +393,34 @@ where
             }
             self.unit_messages_for_network
                 .unbounded_send(RunwayNotificationOut::Response(
-                    Response::ResponseParents(u_hash, full_units),
+                    Response::Parents(u_hash, full_units),
                     node_id,
                 ))
                 .expect("unit_messages_for_network channel should be open")
         } else {
             trace!(target: "AlephBFT-runway", "{:?} Not answering parents request for hash {:?}. Unit not in DAG yet.", self.index(), u_hash);
+        }
+    }
+
+    async fn on_request_newest(&mut self, requester: NodeIndex, salt: u64) {
+        let unit = self.store.newest_unit(requester);
+        let response = NewestUnitResponse {
+            requester,
+            responder: self.index(),
+            unit,
+            salt,
+        };
+
+        let signed_response = Signed::sign(response, self.keybox).await.into_unchecked();
+
+        if let Err(e) =
+            self.unit_messages_for_network
+                .unbounded_send(RunwayNotificationOut::Response(
+                    Response::NewestUnit(signed_response),
+                    requester,
+                ))
+        {
+            error!(target: "AlephBFT-runway", "Unable to send response to network: {}", e);
         }
     }
 
@@ -440,10 +490,77 @@ where
         self.send_consensus_notification(NotificationIn::UnitParents(u_hash, p_hashes));
     }
 
+    fn on_newest_response(
+        &mut self,
+        unchecked_response: UncheckedSigned<NewestUnitResponse<H, D, MK::Signature>, MK::Signature>,
+    ) {
+        let starting_round_sender = match self.starting_round_sender.take() {
+            Some(sender) => sender,
+            None => {
+                log::debug!(target: "AlephBFT-member", "Starting round already sent, ignoring newest unit response");
+                return;
+            }
+        };
+        let response = match unchecked_response.check(self.keybox) {
+            Ok(checked) => checked.into_signable(),
+            Err(e) => {
+                log::debug!(target: "AlephBFT-member", "incorrectly signed response: {:?}", e);
+                return;
+            }
+        };
+
+        if response.salt != self.salt {
+            debug!(target: "AlephBFT-member", "Ignoring newest unit response with an unknown salt: {:?}", response);
+            return;
+        }
+
+        if let Some(unchecked_unit) = response.unit {
+            if unchecked_unit.as_signable().creator() != self.index() {
+                log::debug!(target: "AlephBFT-member", "Not our unit in a response:  {:?}", unchecked_unit.into_signable());
+                return;
+            }
+            let checked_unit = match unchecked_unit.check(self.keybox) {
+                Ok(checked) => checked,
+                Err(e) => {
+                    log::debug!(target: "AlephBFT-member", "incorrectly signed unit in a response: {:?}", e);
+                    return;
+                }
+            };
+            if self
+                .store
+                .unit_by_hash(&checked_unit.as_signable().hash())
+                .is_none()
+            {
+                let starting_round_candidate = checked_unit.as_signable().round() + 1;
+                self.on_unit_received(checked_unit.into(), false);
+                if starting_round_candidate > self.starting_round_value {
+                    self.starting_round_value = starting_round_candidate;
+                }
+            }
+        }
+        self.newest_unit_responders.insert(response.responder);
+        if self.is_starting_round_ready() {
+            trace!(target: "AlephBFT-runway", "sending starting round to creator: {}", self.starting_round_value);
+            if starting_round_sender
+                .send(self.starting_round_value)
+                .is_err()
+            {
+                error!(target: "AlephBFT-runway", "unable to send starting round to creator");
+            }
+        } else {
+            trace!(target: "AlephBFT-runway", "starting round not ready yet, continue collecting newest unit responses");
+            self.starting_round_sender = Some(starting_round_sender);
+        }
+    }
+
+    fn is_starting_round_ready(&self) -> bool {
+        self.after_catch_up_delay && self.newest_unit_responders.len() + 1 >= self.threshold.0
+    }
+
     fn resolve_missing_parents(&mut self, u_hash: &H::Hash) {
         if self.missing_parents.remove(u_hash) {
             self.resolved_requests
-                .unbounded_send(Request::RequestParents(*u_hash))
+                .unbounded_send(Request::Parents(*u_hash))
                 .expect("resolved_requests channel should be open")
         }
     }
@@ -516,7 +633,7 @@ where
             if self.missing_coords.insert(coord) {
                 self.unit_messages_for_network
                     .unbounded_send(RunwayNotificationOut::Request(
-                        Request::RequestCoord(coord),
+                        Request::Coord(coord),
                         Recipient::Node(coord.creator()),
                     ))
                     .expect("unit_messages_for_network channel should be open")
@@ -546,7 +663,7 @@ where
             if self.missing_parents.insert(u_hash) {
                 self.unit_messages_for_network
                     .unbounded_send(RunwayNotificationOut::Request(
-                        Request::RequestParents(u_hash),
+                        Request::Parents(u_hash),
                         recipient,
                     ))
                     .expect("unit_messages_for_network channel should be open")
@@ -582,9 +699,17 @@ where
     }
 
     async fn run(mut self, mut exit: oneshot::Receiver<()>) {
-        info!(target: "AlephBFT-runway", "{:?} Runway starting.", self.index());
-
         let index = self.index();
+
+        info!(target: "AlephBFT-runway", "{:?} Runway starting.", index);
+
+        let notification =
+            RunwayNotificationOut::Request(Request::NewestUnit(self.salt), Recipient::Everyone);
+        if let Err(e) = self.unit_messages_for_network.unbounded_send(notification) {
+            error!(target: "AlephBFT-runway", "{:?} Unable to send the newest unit request: {}", index, e);
+        };
+
+        let mut catch_up_delay = futures_timer::Delay::new(Duration::from_secs(5)).fuse();
 
         info!(target: "AlephBFT-runway", "{:?} Runway started.", index);
         loop {
@@ -608,7 +733,7 @@ where
                 },
 
                 event = self.unit_messages_from_network.next() => match event {
-                    Some(event) => self.on_unit_message(event),
+                    Some(event) => self.on_unit_message(event).await,
                     None => {
                         error!(target: "AlephBFT-runway", "{:?} Unit message stream closed.", index);
                         break;
@@ -622,6 +747,10 @@ where
                         break;
                     }
                 },
+
+                _ = catch_up_delay => {
+                    self.after_catch_up_delay = true;
+                }
 
                 _ = &mut exit => break,
             };
@@ -689,11 +818,8 @@ pub(crate) async fn run<H, D, MK, DP, SH>(
     let (consensus_exit, exit_stream) = oneshot::channel();
     let consensus_config = config.clone();
     let consensus_spawner = spawn_handle.clone();
-    let starting_round = {
-        let (tx, rx) = oneshot::channel();
-        tx.send(0).unwrap();
-        rx
-    };
+    let (starting_round_sender, starting_round) = oneshot::channel();
+
     let consensus_handle = spawn_handle.spawn_essential("runway/consensus", async move {
         consensus::run(
             consensus_config,
@@ -721,10 +847,12 @@ pub(crate) async fn run<H, D, MK, DP, SH>(
         unit_messages_for_network: runway_io.unit_messages_for_network,
         ordered_batch_rx,
         resolved_requests: runway_io.resolved_requests,
+        starting_round_sender,
         node_ix: config.node_ix,
         session_id: config.session_id,
         n_members: config.n_members,
         max_round: config.max_round,
+        salt: 0,
     };
     let (runway_exit, exit_stream) = oneshot::channel();
     let runway = Runway::new(runway_config);

--- a/src/runway.rs
+++ b/src/runway.rs
@@ -689,6 +689,11 @@ pub(crate) async fn run<H, D, MK, DP, SH>(
     let (consensus_exit, exit_stream) = oneshot::channel();
     let consensus_config = config.clone();
     let consensus_spawner = spawn_handle.clone();
+    let starting_round = {
+        let (tx, rx) = oneshot::channel();
+        tx.send(0).unwrap();
+        rx
+    };
     let consensus_handle = spawn_handle.spawn_essential("runway/consensus", async move {
         consensus::run(
             consensus_config,
@@ -696,6 +701,7 @@ pub(crate) async fn run<H, D, MK, DP, SH>(
             consensus_sink,
             ordered_batch_tx,
             consensus_spawner,
+            starting_round,
             exit_stream,
         )
         .await

--- a/src/runway.rs
+++ b/src/runway.rs
@@ -559,6 +559,7 @@ where
             .is_err()
         {
             error!(target: "AlephBFT-runway", "unable to send starting round to creator");
+            self.exiting = true;
             return;
         }
         if let Err(e) = self
@@ -733,6 +734,7 @@ where
             RunwayNotificationOut::Request(Request::NewestUnit(self.salt), Recipient::Everyone);
         if let Err(e) = self.unit_messages_for_network.unbounded_send(notification) {
             error!(target: "AlephBFT-runway", "{:?} Unable to send the newest unit request: {}", index, e);
+            self.exiting = true
         };
 
         let mut catch_up_delay = futures_timer::Delay::new(Duration::from_secs(5)).fuse();

--- a/src/runway.rs
+++ b/src/runway.rs
@@ -18,9 +18,11 @@ use futures::{
     pin_mut, FutureExt, StreamExt,
 };
 use log::{debug, error, info, trace, warn};
-use std::time::Duration;
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
+use std::{
+    collections::hash_map::DefaultHasher,
+    hash::{Hash, Hasher as _},
+    time::Duration,
+};
 
 /// Type for incoming notifications: Runway to Consensus.
 #[derive(Clone, PartialEq)]
@@ -874,7 +876,7 @@ pub(crate) async fn run<H, D, MK, DP, SH>(
         session_id: config.session_id,
         n_members: config.n_members,
         max_round: config.max_round,
-        salt
+        salt,
     };
     let (runway_exit, exit_stream) = oneshot::channel();
     let runway = Runway::new(runway_config);

--- a/src/signed.rs
+++ b/src/signed.rs
@@ -94,6 +94,10 @@ impl<T: Signable, S: Signature> UncheckedSigned<T, S> {
         &self.signable
     }
 
+    pub fn into_signable(self) -> T {
+        self.signable
+    }
+
     pub fn signature(&self) -> S {
         self.signature.clone()
     }
@@ -224,6 +228,10 @@ impl<'a, T: Signable + Index, KB: KeyBox> Signed<'a, T, KB> {
     /// Get a reference to the signed object.
     pub fn as_signable(&self) -> &T {
         &self.unchecked.signable
+    }
+
+    pub fn into_signable(self) -> T {
+        self.unchecked.signable
     }
 
     pub(crate) fn into_unchecked(self) -> UncheckedSigned<T, KB::Signature> {

--- a/src/testing/consensus.rs
+++ b/src/testing/consensus.rs
@@ -11,6 +11,7 @@ use futures::{
     stream::StreamExt,
 };
 use log::trace;
+use crate::testing::mock::complete_oneshot;
 
 fn init_log() {
     let _ = env_logger::builder()
@@ -38,11 +39,7 @@ async fn agree_on_first_batch() {
         exits.push(exit_tx);
         let (batch_tx, batch_rx) = mpsc::unbounded();
         batch_rxs.push(batch_rx);
-        let starting_round = {
-            let (tx, rx) = oneshot::channel();
-            tx.send(0).unwrap();
-            rx
-        };
+        let starting_round = complete_oneshot(0);
         handles.push(spawner.spawn_essential(
             "consensus",
             consensus::run(
@@ -83,11 +80,7 @@ async fn catches_wrong_control_hash() {
     let conf = gen_config(NodeIndex(node_ix), n_nodes.into());
     let (exit_tx, exit_rx) = oneshot::channel();
     let (batch_tx, _batch_rx) = mpsc::unbounded();
-    let starting_round = {
-        let (tx, rx) = oneshot::channel();
-        tx.send(0).unwrap();
-        rx
-    };
+    let starting_round = complete_oneshot(0);
 
     let consensus_handle = spawner.spawn_essential(
         "consensus",

--- a/src/testing/consensus.rs
+++ b/src/testing/consensus.rs
@@ -1,7 +1,7 @@
 use crate::{
     consensus,
     runway::{NotificationIn, NotificationOut},
-    testing::mock::{gen_config, Hasher64, HonestHub, Spawner},
+    testing::mock::{complete_oneshot, gen_config, Hasher64, HonestHub, Spawner},
     units::{ControlHash, PreUnit, Unit},
     Hasher, NodeIndex, SpawnHandle,
 };
@@ -11,7 +11,6 @@ use futures::{
     stream::StreamExt,
 };
 use log::trace;
-use crate::testing::mock::complete_oneshot;
 
 fn init_log() {
     let _ = env_logger::builder()

--- a/src/testing/consensus.rs
+++ b/src/testing/consensus.rs
@@ -38,9 +38,22 @@ async fn agree_on_first_batch() {
         exits.push(exit_tx);
         let (batch_tx, batch_rx) = mpsc::unbounded();
         batch_rxs.push(batch_rx);
+        let starting_round = {
+            let (tx, rx) = oneshot::channel();
+            tx.send(0).unwrap();
+            rx
+        };
         handles.push(spawner.spawn_essential(
             "consensus",
-            consensus::run(conf, rx, tx, batch_tx, spawner.clone(), exit_rx),
+            consensus::run(
+                conf,
+                rx,
+                tx,
+                batch_tx,
+                spawner.clone(),
+                starting_round,
+                exit_rx,
+            ),
         ));
     }
 
@@ -70,10 +83,23 @@ async fn catches_wrong_control_hash() {
     let conf = gen_config(NodeIndex(node_ix), n_nodes.into());
     let (exit_tx, exit_rx) = oneshot::channel();
     let (batch_tx, _batch_rx) = mpsc::unbounded();
+    let starting_round = {
+        let (tx, rx) = oneshot::channel();
+        tx.send(0).unwrap();
+        rx
+    };
 
     let consensus_handle = spawner.spawn_essential(
         "consensus",
-        consensus::run(conf, rx_in, tx_out, batch_tx, spawner.clone(), exit_rx),
+        consensus::run(
+            conf,
+            rx_in,
+            tx_out,
+            batch_tx,
+            spawner.clone(),
+            starting_round,
+            exit_rx,
+        ),
     );
     let control_hash = ControlHash::new(&(vec![None; n_nodes]).into());
     let bad_pu = PreUnit::<Hasher64>::new(1.into(), 0, control_hash);

--- a/src/testing/dag.rs
+++ b/src/testing/dag.rs
@@ -131,9 +131,22 @@ async fn run_consensus_on_dag(
     let (_exit_tx, exit_rx) = oneshot::channel();
     let (batch_tx, mut batch_rx) = mpsc::unbounded();
     let spawner = Spawner::new();
+    let starting_round = {
+        let (tx, rx) = oneshot::channel();
+        tx.send(0).unwrap();
+        rx
+    };
     spawner.spawn(
         "consensus",
-        consensus::run(conf, rx_in, tx_out, batch_tx, spawner.clone(), exit_rx),
+        consensus::run(
+            conf,
+            rx_in,
+            tx_out,
+            batch_tx,
+            spawner.clone(),
+            starting_round,
+            exit_rx,
+        ),
     );
     spawner.spawn("feeder", feeder.run());
     let mut batches = Vec::new();

--- a/src/testing/dag.rs
+++ b/src/testing/dag.rs
@@ -17,6 +17,7 @@ use rand::{distributions::Open01, prelude::*};
 use std::{cmp, time::Duration};
 
 use std::collections::HashMap;
+use crate::testing::mock::complete_oneshot;
 
 #[derive(Clone)]
 struct UnitWithParents {
@@ -131,11 +132,7 @@ async fn run_consensus_on_dag(
     let (_exit_tx, exit_rx) = oneshot::channel();
     let (batch_tx, mut batch_rx) = mpsc::unbounded();
     let spawner = Spawner::new();
-    let starting_round = {
-        let (tx, rx) = oneshot::channel();
-        tx.send(0).unwrap();
-        rx
-    };
+    let starting_round = complete_oneshot(0);
     spawner.spawn(
         "consensus",
         consensus::run(

--- a/src/testing/dag.rs
+++ b/src/testing/dag.rs
@@ -16,8 +16,8 @@ use log::{debug, error, trace};
 use rand::{distributions::Open01, prelude::*};
 use std::{cmp, time::Duration};
 
-use std::collections::HashMap;
 use crate::testing::mock::complete_oneshot;
+use std::collections::HashMap;
 
 #[derive(Clone)]
 struct UnitWithParents {

--- a/src/testing/mock.rs
+++ b/src/testing/mock.rs
@@ -582,3 +582,9 @@ pub fn spawn_honest_member(
     let handle = spawner.spawn_essential("member", member_task);
     (rx_batch, exit_tx, handle)
 }
+
+pub fn complete_oneshot<T>(t: T) -> oneshot::Receiver<T> {
+    let (tx, rx) = oneshot::channel();
+    tx.send(t).unwrap();
+    rx
+}

--- a/src/testing/mock.rs
+++ b/src/testing/mock.rs
@@ -583,7 +583,7 @@ pub fn spawn_honest_member(
     (rx_batch, exit_tx, handle)
 }
 
-pub fn complete_oneshot<T>(t: T) -> oneshot::Receiver<T> {
+pub fn complete_oneshot<T: std::fmt::Debug>(t: T) -> oneshot::Receiver<T> {
     let (tx, rx) = oneshot::channel();
     tx.send(t).unwrap();
     rx

--- a/src/units/store.rs
+++ b/src/units/store.rs
@@ -44,6 +44,20 @@ impl<'a, H: Hasher, D: Data, KB: KeyBox> UnitStore<'a, H, D, KB> {
         self.by_coord.contains_key(coord)
     }
 
+    pub(crate) fn newest_unit(
+        &self,
+        index: NodeIndex,
+    ) -> Option<UncheckedSignedUnit<H, D, KB::Signature>> {
+        Some(
+            self.by_coord
+                .values()
+                .filter(|su| su.as_signable().creator() == index)
+                .max_by_key(|su| su.as_signable().round())?
+                .clone()
+                .into_unchecked(),
+        )
+    }
+
     // Outputs new legit units that are supposed to be sent to Consensus and empties the buffer.
     pub(crate) fn yield_buffer_units(&mut self) -> Vec<SignedUnit<'a, H, D, KB>> {
         std::mem::take(&mut self.legit_buffer)


### PR DESCRIPTION
The version of https://github.com/Cardinal-Cryptography/AlephBFT/pull/134 built on top of `member.rs` refactor (https://github.com/Cardinal-Cryptography/AlephBFT/pull/135) 