### PR TITLE
A0-427: Broadcast own unit after adding to dag

### DIFF
--- a/src/runway.rs
+++ b/src/runway.rs
@@ -255,7 +255,7 @@ where
 
     // TODO: we should return an error and handle it outside
     fn validate_unit(
-        &mut self,
+        &self,
         uu: UncheckedSignedUnit<H, D, MK::Signature>,
     ) -> Option<SignedUnit<'a, H, D, MK>> {
         let su = match uu.check(self.keybox) {
@@ -619,7 +619,6 @@ where
                 self.resolve_missing_parents(&h);
                 if let Some(su) = self.store.unit_by_hash(&h).cloned() {
                     let coord = su.as_signable().coord();
-                    self.resolve_missing_coord(&coord);
                     if coord.creator() == self.index() {
                         trace!(target: "AlephBFT-runway", "{:?} Sending a unit {:?}.", self.index(), h);
                         self.send_message_for_network(RunwayNotificationOut::NewUnit(su.into()));

--- a/src/runway.rs
+++ b/src/runway.rs
@@ -618,8 +618,7 @@ where
                 self.store.add_parents(h, p_hashes);
                 self.resolve_missing_parents(&h);
                 if let Some(su) = self.store.unit_by_hash(&h).cloned() {
-                    let coord = su.as_signable().coord();
-                    if coord.creator() == self.index() {
+                    if su.as_signable().creator() == self.index() {
                         trace!(target: "AlephBFT-runway", "{:?} Sending a unit {:?}.", self.index(), h);
                         self.send_message_for_network(RunwayNotificationOut::NewUnit(su.into()));
                     }

--- a/src/runway.rs
+++ b/src/runway.rs
@@ -237,6 +237,7 @@ where
 
     fn on_unit_received(&mut self, uu: UncheckedSignedUnit<H, D, MK::Signature>, alert: bool) {
         if let Some(su) = self.validate_unit(uu) {
+            self.resolve_missing_coord(&su.as_signable().coord());
             if alert {
                 // Units from alerts explicitly come from forkers, and we want them anyway.
                 self.store.add_unit(su, true);
@@ -254,7 +255,7 @@ where
 
     // TODO: we should return an error and handle it outside
     fn validate_unit(
-        &self,
+        &mut self,
         uu: UncheckedSignedUnit<H, D, MK::Signature>,
     ) -> Option<SignedUnit<'a, H, D, MK>> {
         let su = match uu.check(self.keybox) {
@@ -478,6 +479,7 @@ where
             p_hashes_node_map[ix] = Some(p_hash);
             // There might be some optimization possible here to not validate twice, but overall
             // this piece of code should be executed extremely rarely.
+            self.resolve_missing_coord(&su.as_signable().coord());
             self.add_unit_to_store_unless_fork(su);
         }
 


### PR DESCRIPTION
This PR introduces two changes:

First, it introduces broadcasting each unit created by us immediately after it is added to dag, and secondly, it resolves a missing coordinate request at the moment of adding it to a store instead of doing it at the moment when it is added to dag  