### PR TITLE
AZ 219 remove git force push to main

### DIFF
--- a/.github/workflows/prepare-version-bump.yml
+++ b/.github/workflows/prepare-version-bump.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
     - main
+    - test_main
 
 jobs:
   prepare-new-version:

--- a/.github/workflows/prepare-version-bump.yml
+++ b/.github/workflows/prepare-version-bump.yml
@@ -19,6 +19,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 2
+          ref: ${{ github.base_ref }}
+          token: ${{ secrets.SYNCAZF }}
       - name: check-and-bump
         run: |
           old_version=`cargo next --get`

--- a/.github/workflows/prepare-version-bump.yml
+++ b/.github/workflows/prepare-version-bump.yml
@@ -1,0 +1,58 @@
+name: Autobump version
+
+on:
+  pull_request:
+    branches:
+    - main
+
+jobs:
+  prepare-new-version:
+    environment: Autobump version
+    runs-on: ubuntu-latest
+    # if: ${{ github.repository == 'Cardinal-Cryptography/AlephBFT'}}
+    steps:
+      - name: cargo-next-install
+        run: |
+          cargo install cargo-next --locked
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      - name: check-and-bump
+        run: |
+          old_version=`cargo next --get`
+          # If version on PR branch and main branch have no differences in version -> bump it.
+          # Set version in README.md, commit, tag and push to PR branch.
+          # Assuming nominal version for us is the one in the top level Cargo.toml. 
+          if ! git diff ${{ github.head_ref }} ${{ github.base_ref }} -- Cargo.toml | grep -q '^+version ='; then
+            echo 'Version $old_version has NOT been changed manually between ${{ github.head_ref }} and ${{ github.base_ref }}, patching it now.'
+            cargo next --patch
+            new_version=`cargo next --get`
+            echo 'New version is $new_version.'
+            git add Cargo.toml
+          fi
+          new_version=`cargo next --get`
+          # Make sure README has the same version as Cargo.toml.
+          sed -i "s/^version = \"$version\"$/version = \"$new_version\"/" Cargo.toml
+          git add README.md
+          # Publishing changes to PR branch
+          git config user.email "<>"
+          git config user.name "Version autobump"
+          git commit -m "Setting version to $new_version"
+          git tag -a $new_version -m "Version $new_version created at PR ${{ github.base_ref }} -> ${{ github.head_ref }}"
+      - name: push-to-PR
+        run: |
+          git push origin ${{ github.head_ref }}
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - name: credentials
+        uses: actions-rs/cargo@v1
+        with:
+          command: login
+          args: ${{ secrets.CRATES_IO_TOKEN }}
+      - name: publish
+        run: |
+          if [ -f publishMe ]; then
+            cargo publish
+          fi

--- a/.github/workflows/prepare-version-bump.yml
+++ b/.github/workflows/prepare-version-bump.yml
@@ -43,7 +43,7 @@ jobs:
           git tag -a $new_version -m "Version $new_version created at PR ${{ github.base_ref }} -> ${{ github.head_ref }}"
       - name: push-to-PR
         run: |
-          git push origin ${{ github.head_ref }}
+          git push
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/.github/workflows/prepare-version-bump.yml
+++ b/.github/workflows/prepare-version-bump.yml
@@ -46,16 +46,3 @@ jobs:
       - name: push-to-PR
         run: |
           git push
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-      - name: credentials
-        uses: actions-rs/cargo@v1
-        with:
-          command: login
-          args: ${{ secrets.CRATES_IO_TOKEN }}
-      - name: publish
-        run: |
-          if [ -f publishMe ]; then
-            cargo publish
-          fi

--- a/.github/workflows/prepare-version-bump.yml
+++ b/.github/workflows/prepare-version-bump.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
     - main
-    - test_main
+    - test_main #TODO: disable
 
 jobs:
   prepare-new-version:
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 2
-          ref: ${{ github.base_ref }}
+          ref: ${{ github.head_ref }}
           token: ${{ secrets.SYNCAZF || secrets.MY_TOKEN || github.token }}
       - name: check-and-bump
         run: |

--- a/.github/workflows/prepare-version-bump.yml
+++ b/.github/workflows/prepare-version-bump.yml
@@ -42,7 +42,10 @@ jobs:
           git config user.email "<>"
           git config user.name "Version autobump"
           git commit -m "Setting version to $new_version"
-          git tag -a $new_version -m "Version $new_version created at PR ${{ github.base_ref }} -> ${{ github.head_ref }}"
+          # Create tag with version if it not exist.
+          if ! git rev-parse "$new_version" >/dev/null 2>&1; then
+            git tag -a $new_version -m "Version $new_version created at PR ${{ github.base_ref }} -> ${{ github.head_ref }}"
+          fi
       - name: push-to-PR
         run: |
           git push --follow-tags

--- a/.github/workflows/prepare-version-bump.yml
+++ b/.github/workflows/prepare-version-bump.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           fetch-depth: 2
           ref: ${{ github.base_ref }}
-          token: ${{ secrets.SYNCAZF }}
+          token: ${{ secrets.SYNCAZF || secrets.MY_TOKEN || github.token }}
       - name: check-and-bump
         run: |
           old_version=`cargo next --get`

--- a/.github/workflows/prepare-version-bump.yml
+++ b/.github/workflows/prepare-version-bump.yml
@@ -45,4 +45,4 @@ jobs:
           git tag -a $new_version -m "Version $new_version created at PR ${{ github.base_ref }} -> ${{ github.head_ref }}"
       - name: push-to-PR
         run: |
-          git push
+          git push --follow-tags

--- a/.github/workflows/prepare-version-bump.yml
+++ b/.github/workflows/prepare-version-bump.yml
@@ -9,7 +9,7 @@ jobs:
   prepare-new-version:
     environment: Autobump version
     runs-on: ubuntu-latest
-    # if: ${{ github.repository == 'Cardinal-Cryptography/AlephBFT'}}
+    # if: ${{ github.repository == 'Cardinal-Cryptography/AlephBFT'}} #TODO: disabled for testing
     steps:
       - name: cargo-next-install
         run: |

--- a/.github/workflows/prepare-version-bump.yml
+++ b/.github/workflows/prepare-version-bump.yml
@@ -1,16 +1,15 @@
-name: Autobump version
+name: Autobump version on PR
 
 on:
   pull_request:
     branches:
     - main
-    - test_main #TODO: disable
 
 jobs:
   prepare-new-version:
     environment: Autobump version
     runs-on: ubuntu-latest
-    # if: ${{ github.repository == 'Cardinal-Cryptography/AlephBFT'}} #TODO: disabled for testing
+    if: ${{ github.repository == 'Cardinal-Cryptography/AlephBFT'}}
     steps:
       - name: cargo-next-install
         run: |
@@ -28,10 +27,10 @@ jobs:
           # Set version in README.md, commit, tag and push to PR branch.
           # Assuming nominal version for us is the one in the top level Cargo.toml. 
           if ! git diff ${{ github.head_ref }} ${{ github.base_ref }} -- Cargo.toml | grep -q '^+version ='; then
-            echo 'Version $old_version has NOT been changed manually between ${{ github.head_ref }} and ${{ github.base_ref }}, patching it now.'
+            echo "Version $old_version has NOT been changed manually between ${{ github.head_ref }} and ${{ github.base_ref }}, patching it now."
             cargo next --patch
             new_version=`cargo next --get`
-            echo 'New version is $new_version.'
+            echo "New version is $new_version."
             git add Cargo.toml
           fi
           new_version=`cargo next --get`
@@ -44,7 +43,7 @@ jobs:
           git commit -m "Setting version to $new_version"
           # Create tag with version if it not exist.
           if ! git rev-parse "$new_version" >/dev/null 2>&1; then
-            git tag -a $new_version -m "Version $new_version created at PR ${{ github.base_ref }} -> ${{ github.head_ref }}"
+            git tag -a $new_version -m "Version $new_version created at PR ${{ github.head_ref }} -> ${{ github.base_ref }}"
           fi
       - name: push-to-PR
         run: |

--- a/.github/workflows/push-foundation-repo.yml
+++ b/.github/workflows/push-foundation-repo.yml
@@ -17,6 +17,6 @@ jobs:
         with:
           fetch-depth: 0
           ref: "main"
-          token: ${{ secrets.SYNCAZF || secrets.MY_TOKEN || github.token }}
+          token: ${{ secrets.SYNCAZF }}
       - name: Push to Aleph-Zero-Foundation
         run: git push https://x-access-token:${{ secrets.SYNCAZF }}@github.com/aleph-zero-foundation/AlephBFT.git

--- a/.github/workflows/push-foundation-repo.yml
+++ b/.github/workflows/push-foundation-repo.yml
@@ -20,3 +20,14 @@ jobs:
           token: ${{ secrets.SYNCAZF }}
       - name: Push to Aleph-Zero-Foundation
         run: git push https://x-access-token:${{ secrets.SYNCAZF }}@github.com/aleph-zero-foundation/AlephBFT.git
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - name: credentials
+        uses: actions-rs/cargo@v1
+        with:
+          command: login
+          args: ${{ secrets.CRATES_IO_TOKEN }}
+      - name: publish
+        run: |
+            cargo publish

--- a/.github/workflows/push-foundation-repo.yml
+++ b/.github/workflows/push-foundation-repo.yml
@@ -17,6 +17,6 @@ jobs:
         with:
           fetch-depth: 0
           ref: "main"
-          token: ${{ secrets.SYNCAZF }}
+          token: ${{ secrets.SYNCAZF || secrets.MY_TOKEN || github.token }}
       - name: Push to Aleph-Zero-Foundation
         run: git push https://x-access-token:${{ secrets.SYNCAZF }}@github.com/aleph-zero-foundation/AlephBFT.git

--- a/.github/workflows/push-foundation-repo.yml
+++ b/.github/workflows/push-foundation-repo.yml
@@ -1,7 +1,11 @@
 name: Sync Cardinal-Cryptography repo with Aleph-Zero-Foundation repo
 
 on:
+  # NOTE: changed to "manual workflow dispatch" for now.
+  # TODO: To be automated again, when workflows stabilize
+  # and pushes to main origin will be forbidden.
   workflow_dispatch:
+
 #  workflow_run:
 #    workflows: ["Autobump version"]
 #    branches: [main]

--- a/.github/workflows/push-foundation-repo.yml
+++ b/.github/workflows/push-foundation-repo.yml
@@ -1,11 +1,12 @@
 name: Sync Cardinal-Cryptography repo with Aleph-Zero-Foundation repo
 
 on:
-  workflow_run:
-    workflows: ["Autobump version"]
-    branches: [main]
-    types:
-      - completed
+  workflow_dispatch:
+#  workflow_run:
+#    workflows: ["Autobump version"]
+#    branches: [main]
+#    types:
+#      - completed
 
 jobs:
   sync:

--- a/.github/workflows/push-foundation-repo.yml
+++ b/.github/workflows/push-foundation-repo.yml
@@ -1,4 +1,4 @@
-name: Publish AlephBFT main to crates.io.
+name: Sync Cardinal-Cryptography repo with Aleph-Zero-Foundation repo and publishes AlephBFT main to crates.io.
 
 on:
   # NOTE: changed to "manual workflow dispatch" for now.

--- a/.github/workflows/push-foundation-repo.yml
+++ b/.github/workflows/push-foundation-repo.yml
@@ -1,4 +1,4 @@
-name: Sync Cardinal-Cryptography repo with Aleph-Zero-Foundation repo
+name: Publish AlephBFT main to crates.io.
 
 on:
   # NOTE: changed to "manual workflow dispatch" for now.

--- a/.github/workflows/push-foundation-repo.yml
+++ b/.github/workflows/push-foundation-repo.yml
@@ -1,16 +1,11 @@
-name: Sync Cardinal-Cryptography repo with Aleph-Zero-Foundation repo and publishes AlephBFT main to crates.io.
+name: Sync Cardinal-Cryptography repo with Aleph-Zero-Foundation repo.
 
 on:
-  # NOTE: changed to "manual workflow dispatch" for now.
-  # TODO: To be automated again, when workflows stabilize
-  # and pushes to main origin will be forbidden.
-  workflow_dispatch:
-
-#  workflow_run:
-#    workflows: ["Autobump version"]
-#    branches: [main]
-#    types:
-#      - completed
+  workflow_run:
+    workflows: ["Autobump version"]
+    branches: [main]
+    types:
+      - completed
 
 jobs:
   sync:
@@ -24,14 +19,3 @@ jobs:
           token: ${{ secrets.SYNCAZF }}
       - name: Push to Aleph-Zero-Foundation
         run: git push https://x-access-token:${{ secrets.SYNCAZF }}@github.com/aleph-zero-foundation/AlephBFT.git
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-      - name: credentials
-        uses: actions-rs/cargo@v1
-        with:
-          command: login
-          args: ${{ secrets.CRATES_IO_TOKEN }}
-      - name: publish
-        run: |
-            cargo publish

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
     - main
-    - test_main
 
 jobs:
   autobump:

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -11,47 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'Cardinal-Cryptography/AlephBFT'}}
     steps:
-      - name: checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 2
-      - name: bump
-        run: |
-          version=`grep -e '^version =' Cargo.toml | sed 's/version = //' | sed 's/"//g'`
-          major_version=`echo $version|grep -o -e '^[0-9]*'`
-          minor_version=`echo $version|grep -o -e '^[0-9]*.[0-9]*'|grep -o -e '[0-9]*$'`
-          patch_version=`echo $version|grep -o -e '[0-9]*$'`
-          git config user.email "<>"
-          git config user.name "Version autobump"
-          if git diff HEAD~ -- Cargo.toml | grep -q '^+version ='; then
-            echo 'Version has been bumped manually, bumping readme version and uploading to crates.io'
-            new_version=$major_version.$minor_version
-            sed -i "s/aleph-bft = \"\^[0-9]*.[0-9]*\"$/aleph-bft = \"^$new_version\"/"  README.md
-            git add README.md
-            git commit --amend --no-edit
-            git push -f origin main
-            touch publishMe
-            exit 0
-          fi
-          if [ -e `git diff HEAD~ -- src/` ]; then
-            echo 'No changes in code.'
-            exit 0
-          fi
-          new_version=$major_version.$minor_version.$((patch_version + 1))
-          sed -i "s/^version = \"$version\"$/version = \"$new_version\"/" Cargo.toml
-          git add Cargo.toml
-          git commit --amend --no-edit
-          git push -f origin main
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-      - name: credentials
-        uses: actions-rs/cargo@v1
-        with:
-          command: login
-          args: ${{ secrets.CRATES_IO_TOKEN }}
       - name: publish
         run: |
-          if [ -f publishMe ]; then
-            cargo publish
-          fi
+          cargo publish
+

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -11,7 +11,16 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'Cardinal-Cryptography/AlephBFT'}}
     steps:
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - name: credentials
+        uses: actions-rs/cargo@v1
+        with:
+          command: login
+          args: ${{ secrets.CRATES_IO_TOKEN }}
       - name: publish
         run: |
+          echo 'Uploading to crates.io'
           cargo publish
 

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - main
+    - test_main
 
 jobs:
   autobump:

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,9 +1,15 @@
 name: Autobump version
 
 on:
-  push:
-    branches:
-    - main
+  workflow_dispatch:
+  # NOTE: changed to "manual workflow dispatch" for now.
+  # TODO: To be automated again, when workflows stabilize
+  # and pushes to main origin will be forbidden.
+  #  push:
+  #    branches:
+  #    - main
+
+
 
 jobs:
   autobump:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-bft"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "bit-vec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-bft"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "async-trait",
  "bit-vec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-bft"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "async-trait",
  "bit-vec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-bft"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2018"
 authors = ["Cardinal Cryptography"]
 categories = ["algorithms", "data-structures", "cryptography", "database"]


### PR DESCRIPTION
Changes:
1) in push-foundation-repo.yml automatic publish to crates.io will be disabled for now.
2) removed force-push
3) version is updating on PR branch, not main
4) new version is established before completing the PR