### PR TITLE
A0-539: Add more tests for the alerter (fka AZ-340)

### DIFF
--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-bft"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 authors = ["Cardinal Cryptography"]
 categories = ["algorithms", "data-structures", "cryptography", "database"]

--- a/consensus/src/alerts/mod.rs
+++ b/consensus/src/alerts/mod.rs
@@ -129,9 +129,24 @@ impl<H: Hasher, D: Data, S: Signature, MS: PartialMultisignature> AlertMessage<H
 /// forward them appropriately.
 #[derive(Debug, PartialEq, Eq)]
 enum AlerterResponse<H: Hasher, D: Data, S: Signature, MS: PartialMultisignature> {
+    /// A copy of a fork alert.
+    ///
+    /// This variant should be handled by sending the contained `Alert` via the
+    /// network to the contained `Recipient`.
     ForkAlert(UncheckedSigned<Alert<H, D, S>, S>, Recipient),
+    /// A response to a valid fork alert.
+    ///
+    /// This variant should be handled by starting RMC on the contained hash
+    /// and sending the contained notification (if present) via the network.
     ForkResponse(Option<ForkingNotification<H, D, S>>, H::Hash),
+    /// A request for a fork alert from another node.
+    ///
+    /// This variant should be handled by sending the request via the network
+    /// to the contained `Recipient`.
     AlertRequest(H::Hash, Recipient),
+    /// An internal RMC message, with the sender being the local node.
+    ///
+    /// This variant should be handled by sending the message.
     RmcMessage(RmcMessage<H::Hash, S, MS>),
 }
 

--- a/consensus/src/alerts/mod.rs
+++ b/consensus/src/alerts/mod.rs
@@ -885,7 +885,7 @@ mod tests {
             own_node
                 .on_message(AlertMessage::RmcMessage(other_honest_node, message.clone()))
                 .await,
-            None,
+            Some(AlerterResponse::RmcMessage(message)),
         );
     }
 


### PR DESCRIPTION
[PR 186](https://github.com/Cardinal-Cryptography/AlephBFT/pull/186) promised that tests would be added later. These are those tests.