### PR TITLE
A0-543: Add backup loading mechanism

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-bft"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "aleph-bft-mock",
  "aleph-bft-rmc",

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-bft"
-version = "0.12.1"
+version = "0.12.2"
 edition = "2021"
 authors = ["Cardinal Cryptography"]
 categories = ["algorithms", "data-structures", "cryptography", "database"]

--- a/consensus/src/creation/creator.rs
+++ b/consensus/src/creation/creator.rs
@@ -90,7 +90,7 @@ impl<H: Hasher> Creator<H> {
 mod tests {
     use super::Creator as GenericCreator;
     use crate::{
-        units::{add_units, create_units, creator_set, preunit_to_unit},
+        units::{create_units, creator_set, preunit_to_unit},
         NodeCount, NodeIndex,
     };
     use aleph_bft_mock::Hasher64;
@@ -122,7 +122,7 @@ mod tests {
             .collect();
         let expected_hashes: Vec<_> = new_units.iter().map(|u| u.hash()).collect();
         let creator = &mut creators[0];
-        add_units(creator, &new_units);
+        creator.add_units(&new_units);
         let round = 1;
         assert_eq!(creator.current_round(), 0);
         let (preunit, parent_hashes) = creator
@@ -142,7 +142,7 @@ mod tests {
             .collect();
         let expected_hashes: Vec<_> = new_units.iter().map(|u| u.hash()).collect();
         let creator = &mut creators[0];
-        add_units(creator, &new_units);
+        creator.add_units(&new_units);
         let round = 1;
         assert_eq!(creator.current_round(), 0);
         let (preunit, parent_hashes) = creator
@@ -181,7 +181,7 @@ mod tests {
             .map(|(pu, _)| preunit_to_unit(pu, 0))
             .collect();
         let creator = &mut creators[0];
-        add_units(creator, &new_units);
+        creator.add_units(&new_units);
         let round = 1;
         assert_eq!(creator.current_round(), 0);
         assert!(creator.create_unit(round).is_none())
@@ -220,7 +220,7 @@ mod tests {
                 .collect();
             let expected_hashes: HashSet<_> = new_units.iter().map(|u| u.hash()).collect();
             for creator in creators.iter_mut() {
-                add_units(creator, &new_units);
+                creator.add_units(&new_units);
             }
             expected_hashes_per_round.push(expected_hashes);
         }
@@ -256,7 +256,7 @@ mod tests {
             .map(|(pu, _)| preunit_to_unit(pu, 0))
             .collect();
         let creator = &mut creators[0];
-        add_units(creator, &new_units);
+        creator.add_units(&new_units);
         let round = 1;
         assert!(creator.create_unit(round).is_none());
     }

--- a/consensus/src/runway/backup.rs
+++ b/consensus/src/runway/backup.rs
@@ -130,8 +130,8 @@ mod tests {
     use super::_run_loading_mechanism as run_loading_mechanism;
     use crate::{
         units::{
-            add_units, create_units, creator_set, preunit_to_unchecked_signed_unit,
-            preunit_to_unit, UncheckedSignedUnit as GenericUncheckedSignedUnit,
+            create_units, creator_set, preunit_to_unchecked_signed_unit, preunit_to_unit,
+            UncheckedSignedUnit as GenericUncheckedSignedUnit,
         },
         NodeCount, NodeIndex, Receiver, Round,
     };
@@ -183,7 +183,7 @@ mod tests {
                 .map(|(pre_unit, _)| preunit_to_unit(pre_unit, session_id))
                 .collect();
             for creator in creators.iter_mut() {
-                add_units(creator, &new_units);
+                creator.add_units(&new_units);
             }
         }
         let unit_loader = Loader::new(encoded_data);

--- a/consensus/src/runway/backup.rs
+++ b/consensus/src/runway/backup.rs
@@ -1,0 +1,324 @@
+use crate::{units::UncheckedSignedUnit, Data, Hasher, Round, Sender, Signature};
+use codec::{Decode, Encode, Error as CodecError};
+use futures::channel::oneshot;
+use log::{error, warn};
+use std::io::{Read, Write};
+
+#[derive(Debug)]
+pub enum LoaderError {
+    IO(std::io::Error),
+    Codec(CodecError),
+}
+
+impl From<std::io::Error> for LoaderError {
+    fn from(err: std::io::Error) -> Self {
+        Self::IO(err)
+    }
+}
+
+impl From<CodecError> for LoaderError {
+    fn from(err: CodecError) -> Self {
+        Self::Codec(err)
+    }
+}
+
+pub trait UnitSaver<H: Hasher, D: Data, S: Signature> {
+    fn save(&mut self, unit: UncheckedSignedUnit<H, D, S>) -> Result<(), std::io::Error>;
+}
+
+pub trait UnitLoader<H: Hasher, D: Data, S: Signature> {
+    fn load(self) -> Result<Vec<UncheckedSignedUnit<H, D, S>>, LoaderError>;
+}
+
+impl<H: Hasher, D: Data, S: Signature, W: Write> UnitSaver<H, D, S> for W {
+    fn save(&mut self, unit: UncheckedSignedUnit<H, D, S>) -> Result<(), std::io::Error> {
+        self.write_all(&unit.encode())?;
+        self.flush()?;
+        Ok(())
+    }
+}
+
+impl<H: Hasher, D: Data, S: Signature, R: Read> UnitLoader<H, D, S> for R {
+    fn load(mut self) -> Result<Vec<UncheckedSignedUnit<H, D, S>>, LoaderError> {
+        let mut buf = Vec::new();
+        self.read_to_end(&mut buf)?;
+        let input = &mut &buf[..];
+        let mut result = vec![];
+        while !input.is_empty() {
+            result.push(<UncheckedSignedUnit<H, D, S>>::decode(input)?);
+        }
+        Ok(result)
+    }
+}
+
+fn _load_backup<H: Hasher, D: Data, S: Signature, UL: UnitLoader<H, D, S>>(
+    unit_loader: UL,
+) -> Result<(Vec<UncheckedSignedUnit<H, D, S>>, Round), LoaderError> {
+    let (rounds, units): (Vec<_>, Vec<_>) = unit_loader
+        .load()?
+        .into_iter()
+        .map(|u| (u.as_signable().coord().round(), u))
+        .unzip();
+    let next_round = if let Some(round) = rounds.into_iter().max() {
+        round + 1
+    } else {
+        0
+    };
+    Ok((units, next_round))
+}
+
+fn _on_shutdown(starting_round_tx: oneshot::Sender<Option<Round>>) {
+    if starting_round_tx.send(None).is_err() {
+        warn!(target: "AlephBFT-runway", "Coulnd not send `None` starting round.");
+    }
+}
+
+pub async fn _run_loading_mechanism<H: Hasher, D: Data, S: Signature, UL: UnitLoader<H, D, S>>(
+    unit_loader: UL,
+    loaded_unit_tx: Sender<UncheckedSignedUnit<H, D, S>>,
+    starting_round_tx: oneshot::Sender<Option<Round>>,
+    highest_response_rx: oneshot::Receiver<Round>,
+) {
+    let (units, next_round) = match _load_backup(unit_loader) {
+        Ok((units, next_round)) => (units, next_round),
+        Err(e) => {
+            error!(target: "AlephBFT-runway", "unable to load unit backup: {:?}", e);
+            _on_shutdown(starting_round_tx);
+            return;
+        }
+    };
+
+    let highest_response = match highest_response_rx.await {
+        Ok(highest_response) => highest_response,
+        Err(e) => {
+            error!(target: "AlephBFT-runway", "unable to receive response from unit collections: {:?}", e);
+            _on_shutdown(starting_round_tx);
+            return;
+        }
+    };
+
+    let starting_round = next_round;
+    if starting_round < highest_response {
+        error!(target: "AlephBFT-runway", "backup and unit collection missmatch. Backup got: {:?}, collection got: {:?}", starting_round, highest_response);
+        _on_shutdown(starting_round_tx);
+        return;
+    };
+
+    for u in units {
+        if let Err(e) = loaded_unit_tx.unbounded_send(u) {
+            error!(target: "AlephBFT-runway", "could not send loaded unit: {:?}", e);
+            _on_shutdown(starting_round_tx);
+            return;
+        }
+    }
+
+    if let Err(e) = starting_round_tx.send(Some(starting_round)) {
+        error!(target: "AlephBFT-runway", "could not send starting round: {:?}", e);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::_run_loading_mechanism as run_loading_mechanism;
+    use crate::{
+        units::{
+            add_units, create_units, creator_set, preunit_to_unchecked_signed_unit,
+            preunit_to_unit, UncheckedSignedUnit as GenericUncheckedSignedUnit,
+        },
+        NodeCount, NodeIndex, Receiver, Round,
+    };
+    use aleph_bft_mock::{Data, Hasher64, Keychain, Loader, Signature};
+    use codec::Encode;
+    use futures::{
+        channel::{mpsc::unbounded, oneshot},
+        StreamExt,
+    };
+
+    type UncheckedSignedUnit = GenericUncheckedSignedUnit<Hasher64, Data, Signature>;
+
+    async fn prepare_test(
+        units_n: u16,
+        is_corrupted: bool,
+    ) -> (
+        impl futures::Future,
+        Receiver<UncheckedSignedUnit>,
+        oneshot::Sender<Round>,
+        oneshot::Receiver<Option<Round>>,
+        Vec<UncheckedSignedUnit>,
+    ) {
+        let node_id = NodeIndex(0);
+        let n_members = NodeCount(4);
+        let session_id = 43;
+
+        let mut encoded_data = vec![];
+        let mut data = vec![];
+
+        let mut creators = creator_set(n_members);
+        let keychain = Keychain::new(n_members, node_id);
+
+        for round in 0..units_n {
+            let pre_units = create_units(creators.iter(), round);
+
+            let unit =
+                preunit_to_unchecked_signed_unit(pre_units[0].clone().0, session_id, &keychain)
+                    .await;
+            if is_corrupted {
+                let backup = unit.clone().encode();
+                encoded_data.extend_from_slice(&backup[..backup.len() - 1]);
+            } else {
+                encoded_data.append(&mut unit.clone().encode());
+            }
+            data.push(unit);
+
+            let new_units: Vec<_> = pre_units
+                .into_iter()
+                .map(|(pre_unit, _)| preunit_to_unit(pre_unit, session_id))
+                .collect();
+            for creator in creators.iter_mut() {
+                add_units(creator, &new_units);
+            }
+        }
+        let unit_loader = Loader::new(encoded_data);
+        let (loaded_unit_tx, loaded_unit_rx) = unbounded();
+        let (starting_round_tx, starting_round_rx) = oneshot::channel();
+        let (highest_response_tx, highest_response_rx) = oneshot::channel();
+
+        (
+            run_loading_mechanism(
+                unit_loader,
+                loaded_unit_tx,
+                starting_round_tx,
+                highest_response_rx,
+            ),
+            loaded_unit_rx,
+            highest_response_tx,
+            starting_round_rx,
+            data,
+        )
+    }
+
+    #[tokio::test]
+    async fn nothing_loaded_nothing_collected() {
+        let (task, mut loaded_unit_rx, highest_response_tx, starting_round_rx, _) =
+            prepare_test(0, false).await;
+
+        let handle = tokio::spawn(async {
+            task.await;
+        });
+
+        highest_response_tx.send(0).unwrap();
+
+        handle.await.unwrap();
+
+        assert_eq!(starting_round_rx.await, Ok(Some(0)));
+        assert_eq!(loaded_unit_rx.try_next().unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn something_loaded_nothing_collected() {
+        let (task, mut loaded_unit_rx, highest_response_tx, starting_round_rx, data) =
+            prepare_test(5, false).await;
+
+        let handle = tokio::spawn(async {
+            task.await;
+        });
+
+        highest_response_tx.send(0).unwrap();
+
+        handle.await.unwrap();
+
+        assert_eq!(starting_round_rx.await, Ok(Some(5)));
+        for unit in data {
+            assert_eq!(loaded_unit_rx.next().await, Some(unit));
+        }
+        assert_eq!(loaded_unit_rx.try_next().unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn something_loaded_something_collected() {
+        let (task, mut loaded_unit_rx, highest_response_tx, starting_round_rx, data) =
+            prepare_test(5, false).await;
+
+        let handle = tokio::spawn(async {
+            task.await;
+        });
+
+        highest_response_tx.send(5).unwrap();
+
+        handle.await.unwrap();
+
+        assert_eq!(starting_round_rx.await, Ok(Some(5)));
+        for unit in data {
+            assert_eq!(loaded_unit_rx.next().await, Some(unit));
+        }
+        assert_eq!(loaded_unit_rx.try_next().unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn nothing_loaded_something_collected() {
+        let (task, mut loaded_unit_rx, highest_response_tx, starting_round_rx, _) =
+            prepare_test(0, false).await;
+
+        let handle = tokio::spawn(async {
+            task.await;
+        });
+
+        highest_response_tx.send(1).unwrap();
+
+        handle.await.unwrap();
+
+        assert_eq!(starting_round_rx.await, Ok(None));
+        assert_eq!(loaded_unit_rx.try_next().unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn loaded_smaller_then_collected() {
+        let (task, mut loaded_unit_rx, highest_response_tx, starting_round_rx, _) =
+            prepare_test(3, false).await;
+
+        let handle = tokio::spawn(async {
+            task.await;
+        });
+
+        highest_response_tx.send(4).unwrap();
+
+        handle.await.unwrap();
+
+        assert_eq!(starting_round_rx.await, Ok(None));
+        assert_eq!(loaded_unit_rx.try_next().unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn nothing_collected() {
+        let (task, mut loaded_unit_rx, highest_response_tx, starting_round_rx, _) =
+            prepare_test(3, false).await;
+
+        let handle = tokio::spawn(async {
+            task.await;
+        });
+
+        drop(highest_response_tx);
+
+        handle.await.unwrap();
+
+        assert_eq!(starting_round_rx.await, Ok(None));
+        assert_eq!(loaded_unit_rx.try_next().unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn corrupted_backup() {
+        let (task, mut loaded_unit_rx, highest_response_tx, starting_round_rx, _) =
+            prepare_test(5, true).await;
+
+        let handle = tokio::spawn(async {
+            task.await;
+        });
+
+        highest_response_tx.send(0).unwrap();
+
+        handle.await.unwrap();
+
+        assert_eq!(starting_round_rx.await, Ok(None));
+        assert_eq!(loaded_unit_rx.try_next().unwrap(), None);
+    }
+}

--- a/consensus/src/runway/mod.rs
+++ b/consensus/src/runway/mod.rs
@@ -18,8 +18,10 @@ use futures::{
 use log::{debug, error, info, trace, warn};
 use std::{collections::HashSet, convert::TryFrom};
 
+mod backup;
 mod collection;
 
+pub use backup::{UnitLoader, UnitSaver, _run_loading_mechanism as run_backup_loading_mechanism};
 #[cfg(feature = "initial_unit_collection")]
 use collection::{Collection, IO as CollectionIO};
 pub use collection::{NewestUnitResponse, Salt};

--- a/consensus/src/runway/mod.rs
+++ b/consensus/src/runway/mod.rs
@@ -21,7 +21,7 @@ use std::{collections::HashSet, convert::TryFrom};
 mod backup;
 mod collection;
 
-pub use backup::{UnitLoader, UnitSaver, _run_loading_mechanism as run_backup_loading_mechanism};
+pub use backup::{UnitLoader, UnitSaver};
 #[cfg(feature = "initial_unit_collection")]
 use collection::{Collection, IO as CollectionIO};
 pub use collection::{NewestUnitResponse, Salt};

--- a/consensus/src/runway/mod.rs
+++ b/consensus/src/runway/mod.rs
@@ -21,7 +21,7 @@ use std::{collections::HashSet, convert::TryFrom};
 mod backup;
 mod collection;
 
-pub use backup::{UnitLoader, UnitSaver};
+pub use backup::{_UnitLoader as UnitLoader, _UnitSaver as UnitSaver};
 #[cfg(feature = "initial_unit_collection")]
 use collection::{Collection, IO as CollectionIO};
 pub use collection::{NewestUnitResponse, Salt};

--- a/consensus/src/units/mod.rs
+++ b/consensus/src/units/mod.rs
@@ -13,9 +13,7 @@ mod testing;
 mod validator;
 pub(crate) use store::*;
 #[cfg(test)]
-pub use testing::{
-    add_units, create_units, creator_set, preunit_to_unchecked_signed_unit, preunit_to_unit,
-};
+pub use testing::{create_units, creator_set, preunit_to_unchecked_signed_unit, preunit_to_unit};
 pub use validator::{ValidationError, Validator};
 
 /// The coordinates of a unit, i.e. creator and round. In the absence of forks this uniquely

--- a/consensus/src/units/mod.rs
+++ b/consensus/src/units/mod.rs
@@ -219,13 +219,71 @@ impl<H: Hasher> Unit<H> {
 }
 
 #[cfg(test)]
+pub use tests::{
+    add_units, create_units, creator_set, preunit_to_unchecked_signed_unit, preunit_to_unit,
+};
+
+#[cfg(test)]
 mod tests {
     use crate::{
-        units::{ControlHash, FullUnit, PreUnit},
-        Hasher, NodeIndex,
+        creation::Creator as GenericCreator,
+        units::{
+            ControlHash, FullUnit as GenericFullUnit, PreUnit as GenericPreUnit,
+            UncheckedSignedUnit as GenericUncheckedSignedUnit, Unit as GenericUnit,
+        },
+        Hasher, NodeCount, NodeIndex, Round, SessionId, Signed,
     };
-    use aleph_bft_mock::Hasher64;
+    use aleph_bft_mock::{Data, Hasher64, Keychain, Signature};
     use codec::{Decode, Encode};
+
+    type Creator = GenericCreator<Hasher64>;
+    type PreUnit = GenericPreUnit<Hasher64>;
+    type Unit = GenericUnit<Hasher64>;
+    type FullUnit = GenericFullUnit<Hasher64, Data>;
+    type UncheckedSignedUnit = GenericUncheckedSignedUnit<Hasher64, Data, Signature>;
+
+    pub fn creator_set(n_members: NodeCount) -> Vec<Creator> {
+        let mut result = Vec::new();
+        for i in 0..n_members.0 {
+            result.push(Creator::new(NodeIndex(i), n_members));
+        }
+        result
+    }
+
+    pub fn create_units<'a, C: Iterator<Item = &'a Creator>>(
+        creators: C,
+        round: Round,
+    ) -> Vec<(PreUnit, Vec<<Hasher64 as Hasher>::Hash>)> {
+        let mut result = Vec::new();
+        for creator in creators {
+            result.push(
+                creator
+                    .create_unit(round)
+                    .expect("Creation should succeed."),
+            );
+        }
+        result
+    }
+
+    pub fn preunit_to_unit(preunit: PreUnit, session_id: SessionId) -> Unit {
+        FullUnit::new(preunit, 0, session_id).unit()
+    }
+
+    pub fn add_units(creator: &mut Creator, units: &[Unit]) {
+        for unit in units {
+            creator.add_unit(unit);
+        }
+    }
+
+    pub async fn preunit_to_unchecked_signed_unit(
+        pu: PreUnit,
+        session_id: SessionId,
+        keybox: &Keychain,
+    ) -> UncheckedSignedUnit {
+        let full_unit = FullUnit::new(pu, 0, session_id);
+        let signed_unit = Signed::sign(full_unit, keybox).await;
+        signed_unit.into()
+    }
 
     #[test]
     fn test_full_unit_hash_is_correct() {

--- a/consensus/src/units/testing.rs
+++ b/consensus/src/units/testing.rs
@@ -33,9 +33,11 @@ pub fn preunit_to_unit(preunit: PreUnit, session_id: SessionId) -> Unit {
     FullUnit::new(preunit, 0, session_id).unit()
 }
 
-pub fn add_units(creator: &mut Creator, units: &[Unit]) {
-    for unit in units {
-        creator.add_unit(unit);
+impl Creator {
+    pub fn add_units(&mut self, units: &[Unit]) {
+        for unit in units {
+            self.add_unit(unit);
+        }
     }
 }
 

--- a/consensus/src/units/testing.rs
+++ b/consensus/src/units/testing.rs
@@ -1,0 +1,50 @@
+use crate::{
+    creation::Creator as GenericCreator,
+    units::{
+        FullUnit as GenericFullUnit, PreUnit as GenericPreUnit,
+        UncheckedSignedUnit as GenericUncheckedSignedUnit, Unit as GenericUnit,
+    },
+    Hasher, NodeCount, NodeIndex, Round, SessionId, Signed,
+};
+use aleph_bft_mock::{Data, Hasher64, Keychain, Signature};
+
+type Creator = GenericCreator<Hasher64>;
+type PreUnit = GenericPreUnit<Hasher64>;
+type Unit = GenericUnit<Hasher64>;
+type FullUnit = GenericFullUnit<Hasher64, Data>;
+type UncheckedSignedUnit = GenericUncheckedSignedUnit<Hasher64, Data, Signature>;
+
+pub fn creator_set(n_members: NodeCount) -> Vec<Creator> {
+    (0..n_members.0)
+        .map(|i| Creator::new(NodeIndex(i), n_members))
+        .collect()
+}
+
+pub fn create_units<'a, C: Iterator<Item = &'a Creator>>(
+    creators: C,
+    round: Round,
+) -> Vec<(PreUnit, Vec<<Hasher64 as Hasher>::Hash>)> {
+    creators
+        .map(|c| c.create_unit(round).expect("Creation should succeed."))
+        .collect()
+}
+
+pub fn preunit_to_unit(preunit: PreUnit, session_id: SessionId) -> Unit {
+    FullUnit::new(preunit, 0, session_id).unit()
+}
+
+pub fn add_units(creator: &mut Creator, units: &[Unit]) {
+    for unit in units {
+        creator.add_unit(unit);
+    }
+}
+
+pub async fn preunit_to_unchecked_signed_unit(
+    pu: PreUnit,
+    session_id: SessionId,
+    keybox: &Keychain,
+) -> UncheckedSignedUnit {
+    let full_unit = FullUnit::new(pu, 0, session_id);
+    let signed_unit = Signed::sign(full_unit, keybox).await;
+    signed_unit.into()
+}

--- a/consensus/src/units/validator.rs
+++ b/consensus/src/units/validator.rs
@@ -132,9 +132,7 @@ mod tests {
     use super::{ValidationError::*, Validator as GenericValidator};
     use crate::{
         creation::Creator as GenericCreator,
-        units::{
-            add_units, create_units, creator_set, preunit_to_unchecked_signed_unit, preunit_to_unit,
-        },
+        units::{create_units, creator_set, preunit_to_unchecked_signed_unit, preunit_to_unit},
         NodeCount, NodeIndex,
     };
     use aleph_bft_mock::{Hasher64, Keychain};
@@ -230,7 +228,7 @@ mod tests {
             .take(5)
             .collect();
         let creator = &mut creators[0];
-        add_units(creator, &round_0_units);
+        creator.add_units(&round_0_units);
         let keychain = Keychain::new(n_members, creator_id);
         let validator = Validator::new(session_id, &keychain, max_round, threshold);
         let (preunit, _) = creator
@@ -261,7 +259,7 @@ mod tests {
                 .map(|(preunit, _)| preunit_to_unit(preunit, session_id))
                 .collect();
             for creator in creators.iter_mut() {
-                add_units(creator, &units);
+                creator.add_units(&units);
             }
         }
         let creator = &creators[0];

--- a/consensus/src/units/validator.rs
+++ b/consensus/src/units/validator.rs
@@ -132,63 +132,15 @@ mod tests {
     use super::{ValidationError::*, Validator as GenericValidator};
     use crate::{
         creation::Creator as GenericCreator,
-        units::{
-            FullUnit as GenericFullUnit, PreUnit as GenericPreUnit,
-            UncheckedSignedUnit as GenericUncheckedSignedUnit, Unit as GenericUnit,
+        units::tests::{
+            add_units, create_units, creator_set, preunit_to_unchecked_signed_unit, preunit_to_unit,
         },
-        Hasher, NodeCount, NodeIndex, Round, SessionId, Signed,
+        NodeCount, NodeIndex,
     };
-    use aleph_bft_mock::{Data, Hasher64, Keychain, Signature};
+    use aleph_bft_mock::{Hasher64, Keychain};
 
     type Validator<'a> = GenericValidator<'a, Keychain>;
     type Creator = GenericCreator<Hasher64>;
-    type PreUnit = GenericPreUnit<Hasher64>;
-    type Unit = GenericUnit<Hasher64>;
-    type FullUnit = GenericFullUnit<Hasher64, Data>;
-    type UncheckedSignedUnit = GenericUncheckedSignedUnit<Hasher64, Data, Signature>;
-
-    fn creator_set(n_members: NodeCount) -> Vec<Creator> {
-        let mut result = Vec::new();
-        for i in 0..n_members.0 {
-            result.push(Creator::new(NodeIndex(i), n_members));
-        }
-        result
-    }
-
-    fn create_units<'a, C: Iterator<Item = &'a Creator>>(
-        creators: C,
-        round: Round,
-    ) -> Vec<(PreUnit, Vec<<Hasher64 as Hasher>::Hash>)> {
-        let mut result = Vec::new();
-        for creator in creators {
-            result.push(
-                creator
-                    .create_unit(round)
-                    .expect("Creation should succeed."),
-            );
-        }
-        result
-    }
-
-    fn preunit_to_unit(preunit: PreUnit) -> Unit {
-        FullUnit::new(preunit, 0, 0).unit()
-    }
-
-    fn add_units(creator: &mut Creator, units: &[Unit]) {
-        for unit in units {
-            creator.add_unit(unit);
-        }
-    }
-
-    async fn preunit_to_unchecked_signed_unit(
-        pu: PreUnit,
-        session_id: SessionId,
-        keybox: &Keychain,
-    ) -> UncheckedSignedUnit {
-        let full_unit = FullUnit::new(pu, 0, session_id);
-        let signed_unit = Signed::sign(full_unit, keybox).await;
-        signed_unit.into()
-    }
 
     #[tokio::test]
     async fn validates_initial_unit() {
@@ -274,7 +226,7 @@ mod tests {
         let mut creators = creator_set(n_members);
         let round_0_units: Vec<_> = create_units(creators.iter(), 0)
             .into_iter()
-            .map(|(preunit, _)| preunit_to_unit(preunit))
+            .map(|(preunit, _)| preunit_to_unit(preunit, session_id))
             .take(5)
             .collect();
         let creator = &mut creators[0];
@@ -306,7 +258,7 @@ mod tests {
         for round in 0..round {
             let units: Vec<_> = create_units(creators.iter(), round)
                 .into_iter()
-                .map(|(preunit, _)| preunit_to_unit(preunit))
+                .map(|(preunit, _)| preunit_to_unit(preunit, session_id))
                 .collect();
             for creator in creators.iter_mut() {
                 add_units(creator, &units);

--- a/consensus/src/units/validator.rs
+++ b/consensus/src/units/validator.rs
@@ -132,7 +132,7 @@ mod tests {
     use super::{ValidationError::*, Validator as GenericValidator};
     use crate::{
         creation::Creator as GenericCreator,
-        units::tests::{
+        units::{
             add_units, create_units, creator_set, preunit_to_unchecked_signed_unit, preunit_to_unit,
         },
         NodeCount, NodeIndex,


### PR DESCRIPTION
This is a first part of adding backup loading mechanism. It introduces an implementation of backup loading mechanism that is yet to be integrated.

The idea is that backup mechanism reads Unit data from a file. After that it waits for response from unit collection. Upon receiving unit collection result it check highest round that was backed up. If unit collection had lower result, the backup mechanism sends all units to add them to dag and after that sends the starting round to creator.