### PR TITLE
aleph-bft-mock also needs version bump

### DIFF
--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-bft-mock"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 authors = ["Cardinal Cryptography"]
 documentation = "https://docs.rs/?"


### PR DESCRIPTION
Missed that in the previous PR