### PR TITLE
Bump RMC version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,7 +129,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-bft-rmc"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "aleph-bft-crypto",
  "aleph-bft-mock",

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 description = "AlephBFT is an asynchronous and Byzantine fault tolerant consensus protocol aimed at ordering arbitrary messages (transactions). It has been designed to continuously operate even in the harshest conditions: with no bounds on message-delivery delays and in the presence of malicious actors. This makes it an excellent fit for blockchain-related applications."
 
 [dependencies]
-aleph-bft-rmc = { path = "../rmc", version = "0.3" }
+aleph-bft-rmc = { path = "../rmc", version = "0.4" }
 aleph-bft-types = { path = "../types", version = "0.6" }
 async-trait = "0.1"
 codec = { package = "parity-scale-codec", version = "3.0", default-features = false, features = ["derive"] }

--- a/rmc/Cargo.toml
+++ b/rmc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-bft-rmc"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 authors = ["Cardinal Cryptography"]
 categories = ["algorithms", "cryptography"]


### PR DESCRIPTION
Some API changes got missed during previous work and 0.3.1 was
incompatible with 0.3.0, which ain't acceptable. We also have to yank
0.3.1.