### PR TITLE
A0-1163: Do not log large collection of pending tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-bft"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "aleph-bft-mock",
  "aleph-bft-rmc",

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-bft"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 authors = ["Cardinal Cryptography"]
 categories = ["algorithms", "data-structures", "cryptography", "database"]

--- a/consensus/src/member.rs
+++ b/consensus/src/member.rs
@@ -16,6 +16,7 @@ use futures::{
     pin_mut, FutureExt, StreamExt,
 };
 use futures_timer::Delay;
+use itertools::Itertools;
 use log::{debug, error, info, trace, warn};
 use network::NetworkData;
 use rand::Rng;
@@ -231,10 +232,20 @@ where
                 self.not_resolved_parents.len()
             )?;
         }
+
+        static ITEMS_PRINT_LIMIT: usize = 10;
+
         if !long_time_pending_tasks.is_empty() {
             write!(f, "; pending tasks with counter >= 5 -")?;
-            for task in long_time_pending_tasks.iter() {
-                write!(f, " {},", task)?;
+            let first_tasks = long_time_pending_tasks
+                .iter()
+                .take(ITEMS_PRINT_LIMIT)
+                .map(ToString::to_string)
+                .join(", ");
+            write!(f, " {first_tasks}")?;
+
+            if let Some(remaining) = long_time_pending_tasks.len().checked_sub(ITEMS_PRINT_LIMIT) {
+                write!(f, " and {remaining} more")?
             }
         }
         write!(f, ".")?;

--- a/consensus/src/member.rs
+++ b/consensus/src/member.rs
@@ -237,12 +237,12 @@ where
 
         if !long_time_pending_tasks.is_empty() {
             write!(f, "; pending tasks with counter >= 5 -")?;
-            let first_tasks = long_time_pending_tasks
-                .iter()
-                .take(ITEMS_PRINT_LIMIT)
-                .map(ToString::to_string)
-                .join(", ");
-            write!(f, " {first_tasks}")?;
+            write!(f, " {}", {
+                long_time_pending_tasks
+                    .iter()
+                    .take(ITEMS_PRINT_LIMIT)
+                    .join(", ")
+            })?;
 
             if let Some(remaining) = long_time_pending_tasks.len().checked_sub(ITEMS_PRINT_LIMIT) {
                 write!(f, " and {remaining} more")?


### PR DESCRIPTION
**Problem:** In some situations we can observe massive log lines from AlephBFT.

**Reproduction:** 
```bash
./scripts/run_nodes.sh
# wait some time

# comment out purging command from `scripts/run_nodes.sh`
./scripts/run_nodes.sh -v 2
```

You will see lines like:
```
2022-07-22 16:35:04.119  INFO tokio-runtime-worker AlephBFT-member: Member status report: task queue content: CoordRequest - 46, ParentsRequest - 0, UnitMulticast - 1, RequestNewest - 1; not_resolved_coords.len() - 46; pending tasks with counter >= 5 - ScheduledTask(CoordRequest(UnitCoord { round: 0, creator: NodeIndex(3) }), counter 17), ScheduledTask(CoordRequest(UnitCoord { round: 2, creator: NodeIndex(3) }), counter 17), ScheduledTask(CoordRequest(UnitCoord { round: 1, creator: NodeIndex(3) }), counter 17), ScheduledTask(CoordRequest(UnitCoord { round: 4, creator: NodeIndex(3) }), counter 17), ScheduledTask(CoordRequest(UnitCoord { round: 11, creator: NodeIndex(3) }), counter 17), ScheduledTask(CoordRequest(UnitCoord { round: 3, creator: NodeIndex(3) }), counter 17), ScheduledTask(CoordRequest(UnitCoord { round: 5, creator: NodeIndex(3) }), counter 17), ScheduledTask(CoordRequest(UnitCoord { round: 25, creator: NodeIndex(3) }), counter 17), ScheduledTask(CoordRequest(UnitCoord { round: 8, creator: NodeIndex(3) }), counter 17), ScheduledTask(CoordRequest(UnitCoord { round: 15, creator: NodeIndex(3) }), counter 17), ScheduledTask(CoordRequest(UnitCoord { round: 20, creator: NodeIndex(3) }), counter 17), ScheduledTask(CoordRequest(UnitCoord { round: 9, creator: NodeIndex(3) }), counter 17), ScheduledTask(CoordRequest(UnitCoord { round: 6, creator: NodeIndex(3) }), counter 17), ScheduledTask(CoordRequest(UnitCoord { round: 7, creator: NodeIndex(3) }), counter 17), ScheduledTask(CoordRequest(UnitCoord { round: 13, creator: NodeIndex(3) }), counter 17), ScheduledTask(CoordRequest(UnitCoord { round: 16, creator: NodeIndex(2) }), counter 16), ScheduledTask(CoordRequest(UnitCoord { round: 12, creator: NodeIndex(2) }), counter 15), ScheduledTask(CoordRequest(UnitCoord { round: 18, creator: NodeIndex(3) }), counter 17), ScheduledTask(CoordRequest(UnitCoord { round: 10, creator: NodeIndex(3) }), counter 17), ScheduledTask(CoordRequest(UnitCoord { round: 24, creator: NodeIndex(3) }), counter 17), ScheduledTask(CoordRequest(UnitCoord { round: 16, creator: NodeIndex(3) }), counter 17), ScheduledTask(CoordRequest(UnitCoord { round: 21, creator: NodeIndex(3) }), counter 17), ScheduledTask(CoordRequest(UnitCoord { round: 14, creator: NodeIndex(2) }), counter 16), ScheduledTask(CoordRequest(UnitCoord { round: 17, creator: NodeIndex(3) }), counter 17), ScheduledTask(CoordRequest(UnitCoord { round: 12, creator: NodeIndex(3) }), counter 17), ScheduledTask(CoordRequest(UnitCoord { round: 21, creator: NodeIndex(2) }), counter 13), ScheduledTask(CoordRequest(UnitCoord { round: 17, creator: NodeIndex(2) }), counter 11), ScheduledTask(CoordRequest(UnitCoord { round: 6, creator: NodeIndex(2) }), counter 16), ScheduledTask(CoordRequest(UnitCoord { round: 8, creator: NodeIndex(2) }), counter 16), ScheduledTask(CoordRequest(UnitCoord { round: 14, creator: NodeIndex(3) }), counter 17), ScheduledTask(CoordRequest(UnitCoord { round: 18, creator: NodeIndex(2) }), counter 9), ScheduledTask(CoordRequest(UnitCoord { round: 7, creator: NodeIndex(2) }), counter 14), ScheduledTask(CoordRequest(UnitCoord { round: 13, creator: NodeIndex(2) }), counter 14), ScheduledTask(CoordRequest(UnitCoord { round: 24, creator: NodeIndex(2) }), counter 14), ScheduledTask(CoordRequest(UnitCoord { round: 11, creator: NodeIndex(2) }), counter 13), ScheduledTask(CoordRequest(UnitCoord { round: 22, creator: NodeIndex(2) }), counter 13), ScheduledTask(CoordRequest(UnitCoord { round: 23, creator: NodeIndex(3) }), counter 17), ScheduledTask(CoordRequest(UnitCoord { round: 19, creator: NodeIndex(3) }), counter 17), ScheduledTask(CoordRequest(UnitCoord { round: 4, creator: NodeIndex(2) }), counter 13), ScheduledTask(CoordRequest(UnitCoord { round: 10, creator: NodeIndex(2) }), counter 14), ScheduledTask(CoordRequest(UnitCoord { round: 23, creator: NodeIndex(2) }), counter 16), ScheduledTask(CoordRequest(UnitCoord { round: 22, creator: NodeIndex(3) }), counter 17), ScheduledTask(CoordRequest(UnitCoord { round: 15, creator: NodeIndex(2) }), counter 14), ScheduledTask(CoordRequest(UnitCoord { round: 19, creator: NodeIndex(2) }), counter 15), ScheduledTask(CoordRequest(UnitCoord { round: 20, creator: NodeIndex(2) }), counter 14), ScheduledTask(CoordRequest(UnitCoord { round: 9, creator: NodeIndex(2) }), counter 7),.
```

**Solution:**

We print at most 10 first tasks.

**After change** (up to ~1000 characters):
```
2022-07-25 09:47:16 Member status report: task queue content: CoordRequest - 34, ParentsRequest - 0, UnitMulticast - 1, RequestNewest - 1; not_resolved_coords.len() - 34; pending tasks with counter >= 5 - ScheduledTask(CoordRequest(UnitCoord { round: 0, creator: NodeIndex(2) }), counter 7), ScheduledTask(CoordRequest(UnitCoord { round: 0, creator: NodeIndex(3) }), counter 7), ScheduledTask(CoordRequest(UnitCoord { round: 3, creator: NodeIndex(3) }), counter 7), ScheduledTask(CoordRequest(UnitCoord { round: 1, creator: NodeIndex(2) }), counter 7), ScheduledTask(CoordRequest(UnitCoord { round: 3, creator: NodeIndex(2) }), counter 7), ScheduledTask(CoordRequest(UnitCoord { round: 4, creator: NodeIndex(3) }), counter 7), ScheduledTask(CoordRequest(UnitCoord { round: 5, creator: NodeIndex(2) }), counter 7), ScheduledTask(CoordRequest(UnitCoord { round: 2, creator: NodeIndex(3) }), counter 7), ScheduledTask(CoordRequest(UnitCoord { round: 1, creator: NodeIndex(3) }), counter 7), ScheduledTask(CoordRequest(UnitCoord { round: 4, creator: NodeIndex(2) }), counter 7) and 24 more.
```