### PR TITLE
Set opt-level to 3 in test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: '--lib -- --skip medium'
+          args: '--lib'
   master:
     name: push
     if: "github.event_name == 'push'"
@@ -53,7 +53,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: '--lib -- --skip medium'
+          args: '--lib'
   lint:
     name: lint
     runs-on: ubuntu-20.04

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ members = [
     "fuzz"
 
 ]
+
+[profile.test]
+opt-level = 3


### PR DESCRIPTION
The crash recovery tests are flaky. It seems they sometimes overload the
machine with the 20 or so simulated workers producing messages faster
than they can process them. With opt-level=3 it doesn't seem to happen.
Compilation from a clean state is somewhat longer (46 seconds vs 18
seconds in the one test I did), but you don't often recompile all the
dependencies so this shouldn't be such an issue.

I also reenabled "medium" tests on CI - I hope they will pass now and
it's misleading to have them in the repo but not run on CI anyway.