### PR TITLE
A0-1045: Rewrite network in ordering example to UDP

### DIFF
--- a/examples/ordering/run.sh
+++ b/examples/ordering/run.sh
@@ -63,18 +63,18 @@ done
 
 
 echo "WARNING
-Because of a naive network network implementation, the example might
-fail for certain ranges of parameters (large number of nodes).
-Also, current implementation of AlephBFT does not strictly guarantee
+The current implementation of AlephBFT does not strictly guarantee
 all input data to be included in the output - a property that will
 be added in a future version. This issue occurs when the provider lags
 behind other nodes.
 Therefore, always check logs to see if there are any unexpected
 errors - e.g. connection timeout - or if some crashed nodes are lagging
-behind - messages \"Providing empty data\" are logged, but the total
+behind - messages \"Providing None\" are logged, but the total
 amount of finalized data does not increase for this particular node.
 In such case, try reducing the number of nodes or shortening
-the restart delay.
+the restart delay. Another option is to make more than 1/3 of the nodes
+malfunctioning - with that the protocol will stall while the nodes are
+restarting so that there won't be a set of nodes that run out ahead.
 
 PARAMETERS
 number of nodes: $N_NODES

--- a/examples/ordering/src/network.rs
+++ b/examples/ordering/src/network.rs
@@ -18,6 +18,9 @@ pub struct Network {
     my_id: usize,
     addresses: Vec<SocketAddr>,
     socket: UdpSocket,
+    /// Buffer for incoming data.
+    ///
+    /// It's allocated on the heap, because otherwise it overflows the stack when used inside a future.
     buffer: Box<[u8; MAX_UDP_DATAGRAM_BYTES]>,
 }
 

--- a/examples/ordering/src/network.rs
+++ b/examples/ordering/src/network.rs
@@ -3,19 +3,22 @@ use aleph_bft::{NodeIndex, Recipient};
 use aleph_bft_mock::{Hasher64, PartialMultisignature, Signature};
 use codec::{Decode, Encode};
 use log::error;
-use std::{io::Write, net::SocketAddr};
+use std::net::SocketAddr;
 use tokio::{
-    io::{self, AsyncReadExt},
-    net::TcpListener,
+    io,
+    net::UdpSocket,
     time::{sleep, Duration},
 };
+
+const MAX_UDP_DATAGRAM_BYTES: usize = 65536;
 
 pub type NetworkData = aleph_bft::NetworkData<Hasher64, Data, Signature, PartialMultisignature>;
 
 pub struct Network {
     my_id: usize,
     addresses: Vec<SocketAddr>,
-    listener: TcpListener,
+    socket: UdpSocket,
+    buffer: Box<[u8; MAX_UDP_DATAGRAM_BYTES]>,
 }
 
 impl Network {
@@ -25,16 +28,26 @@ impl Network {
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let my_id = my_id.0;
         assert!(my_id < ports.len());
+
         let addresses = ports
             .iter()
             .map(|p| format!("127.0.0.1:{}", p).parse::<SocketAddr>())
             .collect::<Result<Vec<_>, _>>()?;
-        let listener;
+
+        let socket = Self::bind_socket(addresses[my_id]).await;
+        Ok(Network {
+            my_id,
+            addresses,
+            socket,
+            buffer: Box::new([0; MAX_UDP_DATAGRAM_BYTES]),
+        })
+    }
+
+    async fn bind_socket(address: SocketAddr) -> UdpSocket {
         loop {
-            match TcpListener::bind(addresses[my_id]).await {
-                Ok(l) => {
-                    listener = l;
-                    break;
+            match UdpSocket::bind(address).await {
+                Ok(socket) => {
+                    return socket;
                 }
                 Err(e) => {
                     error!("{}", e);
@@ -43,11 +56,6 @@ impl Network {
                 }
             };
         }
-        Ok(Network {
-            my_id,
-            addresses,
-            listener,
-        })
     }
 
     fn send_to_peer(&self, data: NetworkData, recipient: usize) {
@@ -57,8 +65,11 @@ impl Network {
     }
 
     fn try_send_to_peer(&self, data: NetworkData, recipient: usize) -> io::Result<()> {
-        let mut stream = std::net::TcpStream::connect(self.addresses[recipient])?;
-        stream.write_all(&data.encode())?;
+        let encoded = data.encode();
+        assert!(encoded.len() <= MAX_UDP_DATAGRAM_BYTES);
+
+        self.socket
+            .try_send_to(&encoded, self.addresses[recipient])?;
         Ok(())
     }
 }
@@ -85,17 +96,10 @@ impl aleph_bft::Network<NetworkData> for Network {
     }
 
     async fn next_event(&mut self) -> Option<NetworkData> {
-        let mut buffer = Vec::new();
-        match self.listener.accept().await {
-            Ok((mut socket, _addr)) => match socket.read_to_end(&mut buffer).await {
-                Ok(_) => NetworkData::decode(&mut &buffer[..]).ok(),
-                Err(_) => {
-                    error!("Could not decode incoming data");
-                    None
-                }
-            },
+        match self.socket.recv_from(self.buffer.as_mut()).await {
+            Ok((_len, _addr)) => NetworkData::decode(&mut &self.buffer[..]).ok(),
             Err(e) => {
-                error!("Couldn't accept connection: {:?}", e);
+                error!("Couldn't receive datagram: {:?}", e);
                 None
             }
         }


### PR DESCRIPTION
This solves the problem of establishing a connection with every network
send which seemed to blow up the system's capability to make more
connections in some circumstances. At the same time, the mock network
remains simple with no tracking of open connections and reconnection
attempts. A potential downside is that the UDP datagrams may be lost,
however this should rarely happen locally and the protocol should be
resistant to that in any case.

Some results:

* `./run.sh -n 15 -m 20 -c 6 -o 30 -d 15` - now passes while it hangs at some point on `main`
* `./run.sh -n 30 -m 5 -c 6 -o 30 -d 15` - still doesn't work (because of lack of censorship resistance, it seems)