### PR TITLE
A0-1253 Remove unnecessary wait selects from member and runway

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-bft"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "aleph-bft-mock",
  "aleph-bft-rmc",

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-bft"
-version = "0.19.1"
+version = "0.19.2"
 edition = "2021"
 authors = ["Cardinal Cryptography"]
 categories = ["algorithms", "data-structures", "cryptography", "database"]

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -11,7 +11,7 @@ use crate::{
     extender::Extender,
     runway::{NotificationIn, NotificationOut},
     terminal::Terminal,
-    Hasher, Receiver, Round, Sender, SpawnHandle, Terminator,
+    Hasher, Receiver, Round, Sender, SpawnHandle, Terminator, handle_task_termination,
 };
 
 pub(crate) async fn run<H: Hasher + 'static>(
@@ -90,26 +90,9 @@ pub(crate) async fn run<H: Hasher + 'static>(
     // we stop no matter if received Ok or Err
     terminator.terminate_sync().await;
 
-    if !terminal_handle.is_terminated() {
-        if let Err(()) = terminal_handle.await {
-            warn!(target: "AlephBFT-consensus", "{:?} Terminal finished with an error", index);
-        }
-        debug!(target: "AlephBFT-consensus", "{:?} terminal stopped.", index);
-    }
-
-    if !creator_handle.is_terminated() {
-        if let Err(()) = creator_handle.await {
-            warn!(target: "AlephBFT-consensus", "{:?} Creator finished with an error", index);
-        }
-        debug!(target: "AlephBFT-consensus", "{:?} creator stopped.", index);
-    }
-
-    if !extender_handle.is_terminated() {
-        if let Err(()) = extender_handle.await {
-            warn!(target: "AlephBFT-consensus", "{:?} Extender finished with an error", index);
-        }
-        debug!(target: "AlephBFT-consensus", "{:?} extender stopped.", index);
-    }
+    handle_task_termination(terminal_handle, "AlephBFT-consensus", "Terminal", index).await;
+    handle_task_termination(creator_handle, "AlephBFT-consensus", "Creator", index).await;
+    handle_task_termination(extender_handle, "AlephBFT-consensus", "Extender", index).await;
 
     debug!(target: "AlephBFT", "{:?} All services stopped.", index);
 }

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -1,17 +1,17 @@
 use futures::{
     channel::{mpsc, oneshot},
-    future::FusedFuture,
     FutureExt,
 };
-use log::{debug, warn};
+use log::debug;
 
 use crate::{
     config::Config,
     creation,
     extender::Extender,
+    handle_task_termination,
     runway::{NotificationIn, NotificationOut},
     terminal::Terminal,
-    Hasher, Receiver, Round, Sender, SpawnHandle, Terminator, handle_task_termination,
+    Hasher, Receiver, Round, Sender, SpawnHandle, Terminator,
 };
 
 pub(crate) async fn run<H: Hasher + 'static>(

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -27,7 +27,7 @@ pub use aleph_bft_types::{
 pub use config::{default_config, exponential_slowdown, Config, DelayConfig};
 pub use member::{run_session, LocalIO};
 pub use network::NetworkData;
-pub use terminator::{Terminator, handle_task_termination};
+pub use terminator::{handle_task_termination, Terminator};
 
 type Receiver<T> = futures::channel::mpsc::UnboundedReceiver<T>;
 type Sender<T> = futures::channel::mpsc::UnboundedSender<T>;

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -27,7 +27,7 @@ pub use aleph_bft_types::{
 pub use config::{default_config, exponential_slowdown, Config, DelayConfig};
 pub use member::{run_session, LocalIO};
 pub use network::NetworkData;
-pub use terminator::Terminator;
+pub use terminator::{Terminator, handle_task_termination};
 
 type Receiver<T> = futures::channel::mpsc::UnboundedReceiver<T>;
 type Sender<T> = futures::channel::mpsc::UnboundedSender<T>;

--- a/consensus/src/member.rs
+++ b/consensus/src/member.rs
@@ -1,4 +1,5 @@
 use crate::{
+    handle_task_termination,
     member::Task::{CoordRequest, ParentsRequest, RequestNewest, UnitBroadcast},
     network,
     runway::{
@@ -7,14 +8,13 @@ use crate::{
     },
     task_queue::TaskQueue,
     units::{UncheckedSignedUnit, UnitCoord},
-    handle_task_termination,
     Config, Data, DataProvider, FinalizationHandler, Hasher, MultiKeychain, Network, NodeCount,
     NodeIndex, Receiver, Recipient, Round, Sender, Signature, SpawnHandle, Terminator,
     UncheckedSigned,
 };
 use aleph_bft_types::NodeMap;
 use codec::{Decode, Encode};
-use futures::{channel::mpsc, future::FusedFuture, pin_mut, FutureExt, StreamExt};
+use futures::{channel::mpsc, pin_mut, FutureExt, StreamExt};
 use futures_timer::Delay;
 use itertools::Itertools;
 use log::{debug, error, info, trace, warn};

--- a/consensus/src/member.rs
+++ b/consensus/src/member.rs
@@ -673,30 +673,27 @@ pub async fn run_session<
 
     info!(target: "AlephBFT-member", "{:?} Run ending.", index);
 
-    let terminator_handle = terminator.terminate_sync().fuse();
-    pin_mut!(terminator_handle);
-
-    loop {
-        futures::select! {
-            _ = runway_handle => {
-                debug!(target: "AlephBFT-member", "{:?} Runway stopped.", index);
-            },
-
-            _ = member_handle => {
-                debug!(target: "AlephBFT-member", "{:?} Member stopped.", index);
-            },
-
-            _ = terminator_handle => {}
-
-            complete => break,
-        }
-    }
+    terminator.terminate_sync().await;
 
     if !network_handle.is_terminated() {
         if let Err(()) = network_handle.await {
             warn!(target: "AlephBFT-member", "{:?} Network task stopped with an error", index);
         }
         debug!(target: "AlephBFT-member", "{:?} Network stopped.", index);
+    }
+
+    if !runway_handle.is_terminated() {
+        if let Err(()) = runway_handle.await {
+            warn!(target: "AlephBFT-member", "{:?} Runway task stopped with an error", index);
+        }
+        debug!(target: "AlephBFT-member", "{:?} Runway stopped.", index);
+    }
+
+    if !member_handle.is_terminated() {
+        if let Err(()) = member_handle.await {
+            warn!(target: "AlephBFT-member", "{:?} Member task stopped with an error", index);
+        }
+        debug!(target: "AlephBFT-member", "{:?} Member stopped.", index);
     }
 
     info!(target: "AlephBFT-member", "{:?} Run ended.", index);

--- a/consensus/src/member.rs
+++ b/consensus/src/member.rs
@@ -7,6 +7,7 @@ use crate::{
     },
     task_queue::TaskQueue,
     units::{UncheckedSignedUnit, UnitCoord},
+    handle_task_termination,
     Config, Data, DataProvider, FinalizationHandler, Hasher, MultiKeychain, Network, NodeCount,
     NodeIndex, Receiver, Recipient, Round, Sender, Signature, SpawnHandle, Terminator,
     UncheckedSigned,
@@ -676,26 +677,9 @@ pub async fn run_session<
 
     terminator.terminate_sync().await;
 
-    if !network_handle.is_terminated() {
-        if let Err(()) = network_handle.await {
-            warn!(target: "AlephBFT-member", "{:?} Network task stopped with an error", index);
-        }
-        debug!(target: "AlephBFT-member", "{:?} Network stopped.", index);
-    }
-
-    if !runway_handle.is_terminated() {
-        if let Err(()) = runway_handle.await {
-            warn!(target: "AlephBFT-member", "{:?} Runway task stopped with an error", index);
-        }
-        debug!(target: "AlephBFT-member", "{:?} Runway stopped.", index);
-    }
-
-    if !member_handle.is_terminated() {
-        if let Err(()) = member_handle.await {
-            warn!(target: "AlephBFT-member", "{:?} Member task stopped with an error", index);
-        }
-        debug!(target: "AlephBFT-member", "{:?} Member stopped.", index);
-    }
+    handle_task_termination(network_handle, "AlephBFT-member", "Network", index).await;
+    handle_task_termination(runway_handle, "AlephBFT-member", "Runway", index).await;
+    handle_task_termination(member_handle, "AlephBFT-member", "Member", index).await;
 
     info!(target: "AlephBFT-member", "{:?} Session ended.", index);
 }

--- a/consensus/src/runway/mod.rs
+++ b/consensus/src/runway/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     alerts::{self, Alert, AlertConfig, AlertMessage, ForkProof, ForkingNotification},
-    consensus,
+    consensus, handle_task_termination,
     member::UnitMessage,
     units::{
         ControlHash, PreUnit, SignedUnit, UncheckedSignedUnit, Unit, UnitCoord, UnitStore,
@@ -8,11 +8,10 @@ use crate::{
     },
     Config, Data, DataProvider, FinalizationHandler, Hasher, Index, MultiKeychain, NodeCount,
     NodeIndex, NodeMap, Receiver, Recipient, Round, Sender, Signature, Signed, SpawnHandle,
-    Terminator, UncheckedSigned, handle_task_termination,
+    Terminator, UncheckedSigned,
 };
 use futures::{
     channel::{mpsc, oneshot},
-    future::FusedFuture,
     pin_mut, Future, FutureExt, StreamExt,
 };
 use futures_timer::Delay;

--- a/consensus/src/terminator.rs
+++ b/consensus/src/terminator.rs
@@ -144,13 +144,20 @@ impl Terminator {
     }
 }
 
-pub async fn handle_task_termination<T>(task_handle: T, target: &'static str, name: &'static str, index: aleph_bft_types::NodeIndex)
-where
+pub async fn handle_task_termination<T>(
+    task_handle: T,
+    target: &'static str,
+    name: &'static str,
+    index: aleph_bft_types::NodeIndex,
+) where
     T: FusedFuture<Output = Result<(), ()>>,
 {
     if !task_handle.is_terminated() {
         if let Err(()) = task_handle.await {
-            warn!(target: target, "{:?} {} task stopped with an error", index, name);
+            warn!(
+                target: target,
+                "{:?} {} task stopped with an error", index, name
+            );
         }
         debug!(target: target, "{:?} {} stopped.", index, name);
     }

--- a/consensus/src/terminator.rs
+++ b/consensus/src/terminator.rs
@@ -2,7 +2,7 @@ use futures::{
     channel::oneshot::{channel, Receiver, Sender},
     future::FusedFuture,
 };
-use log::debug;
+use log::{debug, warn};
 
 type TerminatorConnection = (Sender<()>, Receiver<()>);
 
@@ -141,6 +141,18 @@ impl Terminator {
             target: self.component_name,
             "Terminator sent permits to descendants: ready to exit.",
         );
+    }
+}
+
+pub async fn handle_task_termination<T>(task_handle: T, target: &'static str, name: &'static str, index: aleph_bft_types::NodeIndex)
+where
+    T: FusedFuture<Output = Result<(), ()>>,
+{
+    if !task_handle.is_terminated() {
+        if let Err(()) = task_handle.await {
+            warn!(target: target, "{:?} {} task stopped with an error", index, name);
+        }
+        debug!(target: target, "{:?} {} stopped.", index, name);
     }
 }
 


### PR DESCRIPTION
Earlier we introduced selects which wait for unspawned tasks, in order to enable synchronized termination. Now, since all our components are spawned, this is no longer needed. 