### PR TITLE
creator.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,7 @@ dependencies = [
  "aleph-bft-mock",
  "aleph-bft-rmc",
  "aleph-bft-types",
+ "anyhow",
  "async-trait",
  "derivative",
  "env_logger",
@@ -42,6 +43,7 @@ dependencies = [
  "parking_lot",
  "rand",
  "serial_test",
+ "thiserror",
  "tokio",
 ]
 
@@ -161,6 +163,12 @@ checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 
 [[package]]
 name = "arbitrary"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-bft"
-version = "0.20.4"
+version = "0.20.5"
 dependencies = [
  "aleph-bft-mock",
  "aleph-bft-rmc",

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-bft"
-version = "0.20.4"
+version = "0.20.5"
 edition = "2021"
 authors = ["Cardinal Cryptography"]
 categories = ["algorithms", "data-structures", "cryptography", "database"]

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -25,7 +25,7 @@ itertools = "0.10"
 log = "0.4"
 parking_lot = "0.12"
 rand = "0.8"
-thiserror = "1.0.38"
+thiserror = "1.0"
 
 [dev-dependencies]
 aleph-bft-mock = { path = "../mock" }

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -15,6 +15,7 @@ description = "AlephBFT is an asynchronous and Byzantine fault tolerant consensu
 [dependencies]
 aleph-bft-rmc = { path = "../rmc", version = "0.6" }
 aleph-bft-types = { path = "../types", version = "0.8" }
+anyhow = "1.0"
 async-trait = "0.1"
 codec = { package = "parity-scale-codec", version = "3.0", default-features = false, features = ["derive"] }
 derivative = "2.2.0"
@@ -24,6 +25,7 @@ itertools = "0.10"
 log = "0.4"
 parking_lot = "0.12"
 rand = "0.8"
+thiserror = "1.0.38"
 
 [dev-dependencies]
 aleph-bft-mock = { path = "../mock" }

--- a/consensus/src/creation/creator.rs
+++ b/consensus/src/creation/creator.rs
@@ -3,7 +3,6 @@ use crate::{
     Hasher, NodeCount, NodeIndex, NodeMap, Round,
 };
 use anyhow::Result;
-use log::trace;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -49,7 +48,6 @@ impl<H: Hasher> UnitsCollector<H> {
         if self.candidates.get(pid).is_none() {
             self.candidates.insert(pid, hash);
             self.n_candidates += NodeCount(1);
-            trace!(target: "AlephBFT-creator", "Added a new unit: {:#?}.", unit);
         }
     }
 
@@ -78,7 +76,6 @@ fn create_unit<H: Hasher>(
     let parent_hashes = parents.into_values().collect();
 
     let new_preunit = PreUnit::new(node_id, round, control_hash);
-    trace!(target: "AlephBFT-creator", "Created a new unit {:?} at round {:?}.", new_preunit, round);
     (new_preunit, parent_hashes)
 }
 

--- a/consensus/src/creation/creator.rs
+++ b/consensus/src/creation/creator.rs
@@ -29,7 +29,7 @@ impl<H: Hasher> UnitsCollector<H> {
         }
     }
 
-    pub fn can_create(&self, node_id: NodeIndex) -> Option<&NodeMap<H::Hash>> {
+    pub fn prospective_parents(&self, node_id: NodeIndex) -> Option<&NodeMap<H::Hash>> {
         let threshold = (self.candidates.size() * 2) / 3 + NodeCount(1);
 
         if self.n_candidates < threshold {
@@ -100,7 +100,7 @@ impl<H: Hasher> Creator<H> {
         let parents = self
             .round_collectors
             .get(prev_round)?
-            .can_create(self.node_id)?;
+            .prospective_parents(self.node_id)?;
 
         create_unit(self.node_id, parents.clone(), round).into()
     }

--- a/consensus/src/creation/creator.rs
+++ b/consensus/src/creation/creator.rs
@@ -25,17 +25,22 @@ impl<H: Hasher> UnitsCollector<H> {
         if self.candidates.get(pid).is_none() {
             self.candidates.insert(pid, hash);
             self.n_candidates += NodeCount(1);
+            trace!(target: "AlephBFT-creator", "Added a new unit: {:#?}.", unit);
         }
     }
 
     pub fn can_create(&self, node_id: NodeIndex) -> Option<&NodeMap<H::Hash>> {
         let threshold = (self.candidates.size() * 2) / 3 + NodeCount(1);
 
-        if self.n_candidates >= threshold && self.candidates.get(node_id).is_some() {
-            Some(&self.candidates)
-        } else {
-            None
+        if self.n_candidates < threshold {
+            trace!(target: "AlephBFT-creator", "Unable to create a unit: not enough parents available.");
+            return None;
         }
+        if self.candidates.get(node_id).is_none() {
+            trace!(target: "AlephBFT-creator", "Unable to create a unit: missing our own unit in parents.");
+            return None;
+        }
+        Some(&self.candidates)
     }
 }
 

--- a/consensus/src/creation/creator.rs
+++ b/consensus/src/creation/creator.rs
@@ -6,15 +6,15 @@ use log::trace;
 
 #[derive(Clone)]
 struct UnitsCollector<H: Hasher> {
-    n_candidates: NodeCount,
     candidates: NodeMap<H::Hash>,
+    n_candidates: NodeCount,
 }
 
 impl<H: Hasher> UnitsCollector<H> {
     pub fn new(n_members: NodeCount) -> Self {
         Self {
-            n_candidates: NodeCount(0),
             candidates: NodeMap::with_size(n_members),
+            n_candidates: NodeCount(0),
         }
     }
 
@@ -58,9 +58,9 @@ fn create_unit<H: Hasher>(
 }
 
 pub struct Creator<H: Hasher> {
+    round_collectors: Vec<UnitsCollector<H>>,
     node_id: NodeIndex,
     n_members: NodeCount,
-    round_collectors: Vec<UnitsCollector<H>>,
 }
 
 impl<H: Hasher> Creator<H> {
@@ -80,7 +80,7 @@ impl<H: Hasher> Creator<H> {
     fn get_collector_for_round(&mut self, round: Round) -> &mut UnitsCollector<H> {
         let round = usize::from(round);
         if round >= self.round_collectors.len() {
-            let new_size = (round + 1).into();
+            let new_size = round + 1;
             self.round_collectors
                 .resize(new_size, UnitsCollector::new(self.n_members));
         };

--- a/consensus/src/creation/mod.rs
+++ b/consensus/src/creation/mod.rs
@@ -58,11 +58,11 @@ fn very_long_delay() -> Delay {
 async fn create_unit<H: Hasher>(
     round: Round,
     creator: &mut Creator<H>,
-    delay: Option<Delay>,
+    create_delay: Option<Delay>,
     incoming_parents: &mut Receiver<Unit<H>>,
     mut exit: &mut oneshot::Receiver<()>,
 ) -> Result<(PreUnit<H>, Vec<H::Hash>), ()> {
-    let (initial_delay, mut delay_passed) = match delay {
+    let (initial_delay, mut delay_passed) = match create_delay {
         None => (very_long_delay(), true),
         Some(delay) => (delay, false),
     };

--- a/consensus/src/creation/mod.rs
+++ b/consensus/src/creation/mod.rs
@@ -203,8 +203,6 @@ async fn run_creator<H: Hasher>(
         // Skip waiting if someone created a unit of a higher round.
         // In such a case at least 2/3 nodes created units from this round so we aren't skipping a
         // delay we should observe.
-        // NOTE: even we've observed a unit from a higher round, our own unit from previous round
-        // might not be yet added to `creator`. We still might need to wait for its arrival.
         if creator.current_round() <= round {
             let lag = Delay::new(create_lag(round.into()));
 

--- a/consensus/src/creation/mod.rs
+++ b/consensus/src/creation/mod.rs
@@ -205,8 +205,7 @@ async fn run_creator<H: Hasher>(
         // delay we should observe.
         // NOTE: even we've observed a unit from a higher round, our own unit from previous round
         // might not be yet added to `creator`. We still might need to wait for its arrival.
-        let should_delay = creator.current_round() <= round;
-        if should_delay {
+        if creator.current_round() <= round {
             let lag = Delay::new(create_lag(round.into()));
 
             keep_processing_units_until(&mut creator, incoming_parents, lag)

--- a/consensus/src/creation/mod.rs
+++ b/consensus/src/creation/mod.rs
@@ -74,7 +74,7 @@ async fn create_unit<H: Hasher>(
         match creator.create_unit(round) {
             Ok(unit) => return Ok(unit),
             Err(err) => {
-                debug!(target: "AlephBFT-creator", "Creator unable to create a new unit at round {:?}: {}.", round, err)
+                trace!(target: "AlephBFT-creator", "Creator unable to create a new unit at round {}: {}.", round, err)
             }
         }
         process_unit(creator, incoming_parents).await?;

--- a/consensus/src/creation/mod.rs
+++ b/consensus/src/creation/mod.rs
@@ -69,10 +69,12 @@ async fn create_unit<H: Hasher>(
     let mut delay = initial_delay.fuse();
     loop {
         if delay_passed {
-            if let Some(result) = creator.create_unit(round) {
-                return Ok(result);
+            match creator.create_unit(round) {
+                Ok(unit) => return Ok(unit),
+                Err(err) => {
+                    debug!(target: "AlephBFT-creator", "Creator unable to create a new unit at round {:?}: {}.", round, err)
+                }
             }
-            debug!(target: "AlephBFT-creator", "Creator unable to create a new unit at round {:?}.", round);
         }
         futures::select! {
             unit = incoming_parents.next() => match unit {

--- a/consensus/src/creation/mod.rs
+++ b/consensus/src/creation/mod.rs
@@ -131,7 +131,7 @@ pub async fn run<H: Hasher>(
     mut terminator: Terminator,
 ) {
     futures::select! {
-        _= read_starting_round_and_run_creator(conf, &mut io, &mut starting_round).fuse() =>
+        _ = read_starting_round_and_run_creator(conf, &mut io, &mut starting_round).fuse() =>
             debug!(target: "AlephBFT-creator", "Creator is about to finish."),
         _ = terminator.get_exit() =>
             debug!(target: "AlephBFT-creator", "Received an exit signal."),

--- a/consensus/src/creation/mod.rs
+++ b/consensus/src/creation/mod.rs
@@ -59,10 +59,10 @@ async fn create_unit<H: Hasher>(
     incoming_parents: &mut Receiver<Unit<H>>,
     mut exit: &mut oneshot::Receiver<()>,
 ) -> Result<(PreUnit<H>, Vec<H::Hash>), ()> {
-    const THIRTY_MINUTES: Duration = Duration::from_secs(30 * 60);
+    const VERY_LONG_TIME: Duration = Duration::from_secs(30 * 60);
 
     let initial_delay = match skip_delay {
-        true => THIRTY_MINUTES,
+        true => VERY_LONG_TIME,
         false => create_lag(round.into()),
     };
     let mut delay = Delay::new(initial_delay).fuse();
@@ -87,7 +87,7 @@ async fn create_unit<H: Hasher>(
                     warn!(target: "AlephBFT-creator", "Delay passed at round {} despite us not waiting for it.", &round);
                 }
                 delay_passed = true;
-                delay = Delay::new(THIRTY_MINUTES).fuse();
+                delay = Delay::new(VERY_LONG_TIME).fuse();
             },
             _ = exit => {
                 debug!(target: "AlephBFT-creator", "Received exit signal.");

--- a/consensus/src/creation/mod.rs
+++ b/consensus/src/creation/mod.rs
@@ -206,7 +206,8 @@ async fn run_creator<H: Hasher>(
         // Skip waiting if someone created a unit of a higher round.
         // In such a case at least 2/3 nodes created units from this round so we aren't skipping a
         // delay we should observe.
-        if creator.current_round() <= round {
+        let skip_delay = creator.current_round() > round;
+        if !skip_delay {
             let lag = Delay::new(create_lag(round.into()));
 
             keep_processing_units_until(&mut creator, incoming_parents, lag)

--- a/consensus/src/creation/mod.rs
+++ b/consensus/src/creation/mod.rs
@@ -22,7 +22,7 @@ pub use creator::Creator;
 /// The configuration needed for the process creating new units.
 #[derive(Clone)]
 pub struct Config {
-    node_ix: NodeIndex,
+    node_id: NodeIndex,
     n_members: NodeCount,
     create_lag: DelaySchedule,
     max_round: Round,
@@ -31,7 +31,7 @@ pub struct Config {
 impl Debug for Config {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Config")
-            .field("node ix", &self.node_ix)
+            .field("node id", &self.node_id)
             .field("member count", &self.n_members)
             .field("max round", &self.max_round)
             .finish()
@@ -41,7 +41,7 @@ impl Debug for Config {
 impl From<GeneralConfig> for Config {
     fn from(conf: GeneralConfig) -> Self {
         Config {
-            node_ix: conf.node_ix,
+            node_id: conf.node_ix,
             n_members: conf.n_members,
             create_lag: conf.delay_config.unit_creation_delay,
             max_round: conf.max_round,
@@ -185,12 +185,12 @@ async fn run_creator<H: Hasher>(
     starting_round: Round,
 ) -> anyhow::Result<(), CreatorError> {
     let Config {
-        node_ix,
+        node_id,
         n_members,
         create_lag,
         max_round,
     } = conf;
-    let mut creator = Creator::new(node_ix, n_members);
+    let mut creator = Creator::new(node_id, n_members);
     let incoming_parents = &mut io.incoming_parents;
     let outgoing_units = &io.outgoing_units;
 

--- a/consensus/src/creation/mod.rs
+++ b/consensus/src/creation/mod.rs
@@ -205,7 +205,7 @@ async fn run_creator<H: Hasher>(
         // delay we should observe.
         // NOTE: even we've observed a unit from a higher round, our own unit from previous round
         // might not be yet added to `creator`. We still might need to wait for its arrival.
-        let should_delay = !(creator.current_round() > round);
+        let should_delay = creator.current_round() <= round;
         if should_delay {
             let lag = Delay::new(create_lag(round.into()));
 

--- a/consensus/src/creation/mod.rs
+++ b/consensus/src/creation/mod.rs
@@ -194,9 +194,7 @@ async fn run_creator<H: Hasher>(
         if !skip_delay {
             let lag = Delay::new(create_lag(round.into()));
 
-            keep_processing_units_until(&mut creator, incoming_parents, lag)
-                .await
-                .map_err(|_| CreatorError::ParentsChannelClosed)?;
+            keep_processing_units_until(&mut creator, incoming_parents, lag).await?;
         }
 
         let (unit, parent_hashes) = create_unit(round, &mut creator, incoming_parents).await?;


### PR DESCRIPTION
1. slightly refactored creator.rs: added `UnitsCollector`; added more detailed `trace` logging
2. setting initial delay to `30` minutes in creator if `can_create` flag is true - it should help in situations when we are still waiting for our own unit