### PR TITLE
A0-1054: Simplify mock Saver and Loader.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-bft-mock"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "aleph-bft-types",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-bft"
-version = "0.20.6"
+version = "0.20.7"
 dependencies = [
  "aleph-bft-mock",
  "aleph-bft-rmc",
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-bft-mock"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "aleph-bft-types",
  "async-trait",

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-bft"
-version = "0.20.6"
+version = "0.20.7"
 edition = "2021"
 authors = ["Cardinal Cryptography"]
 categories = ["algorithms", "data-structures", "cryptography", "database"]

--- a/consensus/src/testing/mod.rs
+++ b/consensus/src/testing/mod.rs
@@ -86,7 +86,7 @@ pub fn spawn_honest_member(
     let spawner_inner = spawner;
     let unit_loader = Loader::new(units);
     let saved_state = Arc::new(Mutex::new(vec![]));
-    let unit_saver = Saver::from_data(saved_state.clone());
+    let unit_saver = Saver::from(saved_state.clone());
     let local_io = LocalIO::new(data_provider, finalization_handler, unit_saver, unit_loader);
     let member_task = async move {
         let keychain = Keychain::new(n_members, node_index);

--- a/consensus/src/testing/mod.rs
+++ b/consensus/src/testing/mod.rs
@@ -86,7 +86,7 @@ pub fn spawn_honest_member(
     let spawner_inner = spawner;
     let unit_loader = Loader::new(units);
     let saved_state = Arc::new(Mutex::new(vec![]));
-    let unit_saver = Saver::new(saved_state.clone());
+    let unit_saver = Saver::from_data(saved_state.clone());
     let local_io = LocalIO::new(data_provider, finalization_handler, unit_saver, unit_loader);
     let member_task = async move {
         let keychain = Keychain::new(n_members, node_index);

--- a/consensus/src/testing/mod.rs
+++ b/consensus/src/testing/mod.rs
@@ -86,7 +86,7 @@ pub fn spawn_honest_member(
     let spawner_inner = spawner;
     let unit_loader = Loader::new(units);
     let saved_state = Arc::new(Mutex::new(vec![]));
-    let unit_saver = Saver::from(saved_state.clone());
+    let unit_saver: Saver = saved_state.clone().into();
     let local_io = LocalIO::new(data_provider, finalization_handler, unit_saver, unit_loader);
     let member_task = async move {
         let keychain = Keychain::new(n_members, node_index);

--- a/examples/blockchain/src/main.rs
+++ b/examples/blockchain/src/main.rs
@@ -2,14 +2,12 @@ use std::{
     collections::HashMap,
     io::Write,
     str::FromStr,
-    sync::Arc,
     time::{Duration, Instant},
 };
 
 use clap::Parser;
 use futures::{channel::oneshot, StreamExt};
 use log::{debug, error, info};
-use parking_lot::Mutex;
 use time::{macros::format_description, OffsetDateTime};
 
 use aleph_bft::{run_session, NodeIndex, Terminator};
@@ -132,7 +130,7 @@ async fn main() {
         let keychain = Keychain::new(args.n_members.into(), args.my_id.into());
         let config = aleph_bft::default_config(args.n_members.into(), args.my_id.into(), 0);
         let backup_loader = Loader::new(vec![]);
-        let backup_saver = Saver::new(Arc::new(Mutex::new(vec![])));
+        let backup_saver = Saver::new();
         let local_io = aleph_bft::LocalIO::new(
             data_provider,
             finalization_handler,

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -219,9 +219,8 @@ pub fn spawn_honest_member_with_config(
     network: impl 'static + NetworkT<FuzzNetworkData>,
     mk: Keychain,
 ) -> (oneshot::Sender<()>, UReceiver<Data>) {
-    let units = Arc::new(Mutex::new(vec![]));
-    let unit_loader = Loader::new((*units.lock()).clone());
-    let unit_saver = Saver::new(units);
+    let unit_loader = Loader::new(vec![]);
+    let unit_saver = Saver::new();
     let data_provider = DataProvider::new();
     let (finalization_handler, finalization_rx) = FinalizationHandler::new();
     let local_io = LocalIO::new(data_provider, finalization_handler, unit_saver, unit_loader);

--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-bft-mock"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2021"
 authors = ["Cardinal Cryptography"]
 documentation = "https://docs.rs/?"

--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-bft-mock"
-version = "0.8.4"
+version = "0.9.0"
 edition = "2021"
 authors = ["Cardinal Cryptography"]
 documentation = "https://docs.rs/?"

--- a/mock/src/dataio.rs
+++ b/mock/src/dataio.rs
@@ -92,7 +92,10 @@ pub struct Saver {
 }
 
 impl Saver {
-    pub fn new(data: Arc<Mutex<Vec<u8>>>) -> Self {
+    pub fn new() -> Self {
+        Self { data: Arc::new(Mutex::new(vec![])) }
+    }
+    pub fn from_data(data: Arc<Mutex<Vec<u8>>>) -> Self {
         Self { data }
     }
 }

--- a/mock/src/dataio.rs
+++ b/mock/src/dataio.rs
@@ -97,7 +97,10 @@ impl Saver {
             data: Arc::new(Mutex::new(vec![])),
         }
     }
-    pub fn from_data(data: Arc<Mutex<Vec<u8>>>) -> Self {
+}
+
+impl From<Arc<Mutex<Vec<u8>>>> for Saver {
+    fn from(data: Arc<Mutex<Vec<u8>>>) -> Self {
         Self { data }
     }
 }

--- a/mock/src/dataio.rs
+++ b/mock/src/dataio.rs
@@ -93,7 +93,9 @@ pub struct Saver {
 
 impl Saver {
     pub fn new() -> Self {
-        Self { data: Arc::new(Mutex::new(vec![])) }
+        Self {
+            data: Arc::new(Mutex::new(vec![])),
+        }
     }
     pub fn from_data(data: Arc<Mutex<Vec<u8>>>) -> Self {
         Self { data }


### PR DESCRIPTION
* Removed unnecessary cloning a `vec` under a `mutex`
* Refactored the `Saver::new` function to take no arguments.
* Implemented `From` trait for `Saver` which creates a Saver from existing data (same behavior as ::new before the refactor)