### PR TITLE
A0-2583: Prevent reaching max round too fast

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-bft"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "aleph-bft-mock",
  "aleph-bft-rmc",

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ More details are available [in the book][reference-link-implementation-details].
 - Import AlephBFT in your crate
   ```toml
   [dependencies]
-  aleph-bft = "^0.21"
+  aleph-bft = "^0.22"
   ```
 - The main entry point is the `run_session` function, which returns a Future that runs the
   consensus algorithm.

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-bft"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 authors = ["Cardinal Cryptography"]
 categories = ["algorithms", "data-structures", "cryptography", "database"]

--- a/consensus/src/config.rs
+++ b/consensus/src/config.rs
@@ -162,6 +162,21 @@ pub fn default_config(
     )
 }
 
+/// Creates a [`DelayConfig`] with default parameters, suggested by the creators of this package.
+pub fn default_delay_config() -> DelayConfig {
+    DelayConfig {
+        tick_interval: Duration::from_millis(10),
+        unit_rebroadcast_interval_min: Duration::from_millis(15000),
+        unit_rebroadcast_interval_max: Duration::from_millis(20000),
+        unit_creation_delay: default_unit_creation_delay(),
+        coord_request_delay: default_coord_request_delay(),
+        coord_request_recipients: default_coord_request_recipients(),
+        parent_request_delay: Arc::new(|_| Duration::from_millis(3000)),
+        parent_request_recipients: Arc::new(|_| 1),
+        newest_request_delay: Arc::new(|_| Duration::from_millis(3000)),
+    }
+}
+
 /// 5000, 500, 500, 500, ... (till step 3000), 500, 500*1.005, 500*(1.005)^2, 500*(1.005)^3, ..., 10742207 (last step)
 fn default_unit_creation_delay() -> DelaySchedule {
     Arc::new(|t| match t {
@@ -183,20 +198,6 @@ fn default_coord_request_delay() -> DelaySchedule {
 /// 3, 3, 3, 1, 1, 1, 1, ...
 fn default_coord_request_recipients() -> RecipientCountSchedule {
     Arc::new(|t| if t <= 2 { 3 } else { 1 })
-}
-
-fn default_delay_config() -> DelayConfig {
-    DelayConfig {
-        tick_interval: Duration::from_millis(10),
-        unit_rebroadcast_interval_min: Duration::from_millis(15000),
-        unit_rebroadcast_interval_max: Duration::from_millis(20000),
-        unit_creation_delay: default_unit_creation_delay(),
-        coord_request_delay: default_coord_request_delay(),
-        coord_request_recipients: default_coord_request_recipients(),
-        parent_request_delay: Arc::new(|_| Duration::from_millis(3000)),
-        parent_request_recipients: Arc::new(|_| 1),
-        newest_request_delay: Arc::new(|_| Duration::from_millis(3000)),
-    }
 }
 
 fn time_to_reach_round(round: Round, delay_schedule: &DelaySchedule) -> Duration {

--- a/consensus/src/config.rs
+++ b/consensus/src/config.rs
@@ -141,10 +141,9 @@ pub fn create_config(
     })
 }
 
-/// Creates a [`Config`], allowing the user to omit specifying the `delay_config`
-/// in which case it will be set to default, suggested by the creators of this package.
-/// `time_to_reach_max_round` is a lower bound on the time needed to reach the maximum round
-/// expected by the user and is only used for verification.
+/// Creates a [`Config`], allowing the user to omit specifying the `delay_config` in which case it will be
+/// set to default, suggested by the creators of this package. `time_to_reach_max_round` is a lower bound
+/// on the time needed to reach the maximum round expected by the user and is only used for verification.
 pub fn default_config(
     n_members: NodeCount,
     node_ix: NodeIndex,

--- a/consensus/src/config.rs
+++ b/consensus/src/config.rs
@@ -167,7 +167,7 @@ mod tests {
     fn creation_delay_for_tests() -> DelaySchedule {
         Arc::new(move |t| match t {
             0 => Duration::from_millis(2000),
-            _ => exponential_slowdown(t, 300.0 as f64, 5000, 1.005),
+            _ => exponential_slowdown(t, 300.0, 5000, 1.005),
         })
     }
 
@@ -205,26 +205,20 @@ mod tests {
     #[test]
     fn low_round_not_causing_slowdown_fails_the_check() {
         let round_delays = creation_delay_for_tests();
-        assert_eq!(
-            reaching_round_takes_at_least(
-                5000,
-                round_delays,
-                Duration::from_millis(MILLIS_IN_WEEK)
-            ),
-            false
-        );
+        assert!(!reaching_round_takes_at_least(
+            5000,
+            round_delays,
+            Duration::from_millis(MILLIS_IN_WEEK)
+        ),);
     }
 
     #[test]
     fn high_round_causing_slowdown_passes_the_check() {
         let round_delays = creation_delay_for_tests();
-        assert_eq!(
-            reaching_round_takes_at_least(
-                7000,
-                round_delays,
-                Duration::from_millis(MILLIS_IN_WEEK)
-            ),
-            true
-        );
+        assert!(reaching_round_takes_at_least(
+            7000,
+            round_delays,
+            Duration::from_millis(MILLIS_IN_WEEK)
+        ));
     }
 }

--- a/consensus/src/config.rs
+++ b/consensus/src/config.rs
@@ -114,10 +114,8 @@ pub fn exponential_slowdown(
     Duration::from_millis(delay)
 }
 
-/// Creates a [`Config`], allowing the user to omit specifying `max_round` and `delay_config`
-/// in which case they will be set do default values, suggested by the creators of this package.
-/// `time_to_reach_max_round` is a lower bound on the time needed to reach the maximum round
-/// expected by the user and is only used for verification.
+/// Creates a [`Config`] which wraps the passed arguments. `time_to_reach_max_round` is a lower bound
+/// on the time needed to reach the maximum round expected by the user and is only used for verification.
 pub fn create_config(
     n_members: NodeCount,
     node_ix: NodeIndex,
@@ -143,6 +141,10 @@ pub fn create_config(
     })
 }
 
+/// Creates a [`Config`], allowing the user to omit specifying the `delay_config`
+/// in which case it will be set to default, suggested by the creators of this package.
+/// `time_to_reach_max_round` is a lower bound on the time needed to reach the maximum round
+/// expected by the user and is only used for verification.
 pub fn default_config(
     n_members: NodeCount,
     node_ix: NodeIndex,

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -23,10 +23,10 @@ pub(crate) async fn run<H: Hasher + 'static>(
     starting_round: oneshot::Receiver<Option<Round>>,
     mut terminator: Terminator,
 ) {
-    debug!(target: "AlephBFT", "{:?} Starting all services...", conf.node_ix);
+    debug!(target: "AlephBFT", "{:?} Starting all services...", conf.node_ix());
 
-    let n_members = conf.n_members;
-    let index = conf.node_ix;
+    let n_members = conf.n_members();
+    let index = conf.node_ix();
 
     let (electors_tx, electors_rx) = mpsc::unbounded();
     let mut extender = Extender::<H>::new(index, n_members, electors_rx, ordered_batch_tx);

--- a/consensus/src/creation/mod.rs
+++ b/consensus/src/creation/mod.rs
@@ -41,10 +41,10 @@ impl Debug for Config {
 impl From<GeneralConfig> for Config {
     fn from(conf: GeneralConfig) -> Self {
         Config {
-            node_id: conf.node_ix,
-            n_members: conf.n_members,
-            create_lag: conf.delay_config.unit_creation_delay,
-            max_round: conf.max_round,
+            node_id: conf.node_ix(),
+            n_members: conf.n_members(),
+            create_lag: conf.delay_config().unit_creation_delay.clone(),
+            max_round: conf.max_round(),
         }
     }
 }

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -24,7 +24,7 @@ pub use aleph_bft_types::{
     PartialMultisignature, PartiallyMultisigned, Recipient, Round, SessionId, Signable, Signature,
     SignatureError, SignatureSet, Signed, SpawnHandle, TaskHandle, UncheckedSigned,
 };
-pub use config::{create_config, exponential_slowdown, Config, DelayConfig};
+pub use config::{create_config, default_config, exponential_slowdown, Config, DelayConfig};
 pub use member::{run_session, LocalIO};
 pub use network::NetworkData;
 pub use terminator::{handle_task_termination, Terminator};

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -24,7 +24,7 @@ pub use aleph_bft_types::{
     PartialMultisignature, PartiallyMultisigned, Recipient, Round, SessionId, Signable, Signature,
     SignatureError, SignatureSet, Signed, SpawnHandle, TaskHandle, UncheckedSigned,
 };
-pub use config::{default_config, exponential_slowdown, Config, DelayConfig};
+pub use config::{create_config, exponential_slowdown, Config, DelayConfig};
 pub use member::{run_session, LocalIO};
 pub use network::NetworkData;
 pub use terminator::{handle_task_termination, Terminator};

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -24,7 +24,9 @@ pub use aleph_bft_types::{
     PartialMultisignature, PartiallyMultisigned, Recipient, Round, SessionId, Signable, Signature,
     SignatureError, SignatureSet, Signed, SpawnHandle, TaskHandle, UncheckedSigned,
 };
-pub use config::{create_config, default_config, exponential_slowdown, Config, DelayConfig};
+pub use config::{
+    create_config, default_config, default_delay_config, exponential_slowdown, Config, DelayConfig,
+};
 pub use member::{run_session, LocalIO};
 pub use network::NetworkData;
 pub use terminator::{handle_task_termination, Terminator};

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -24,9 +24,7 @@ pub use aleph_bft_types::{
     PartialMultisignature, PartiallyMultisigned, Recipient, Round, SessionId, Signable, Signature,
     SignatureError, SignatureSet, Signed, SpawnHandle, TaskHandle, UncheckedSigned,
 };
-pub use config::{
-    default_config, exponential_slowdown, reaching_round_takes_at_least, Config, DelayConfig,
-};
+pub use config::{default_config, exponential_slowdown, Config, DelayConfig};
 pub use member::{run_session, LocalIO};
 pub use network::NetworkData;
 pub use terminator::{handle_task_termination, Terminator};

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -24,7 +24,9 @@ pub use aleph_bft_types::{
     PartialMultisignature, PartiallyMultisigned, Recipient, Round, SessionId, Signable, Signature,
     SignatureError, SignatureSet, Signed, SpawnHandle, TaskHandle, UncheckedSigned,
 };
-pub use config::{default_config, exponential_slowdown, Config, DelayConfig};
+pub use config::{
+    default_config, exponential_slowdown, reaching_round_takes_at_least, Config, DelayConfig,
+};
 pub use member::{run_session, LocalIO};
 pub use network::NetworkData;
 pub use terminator::{handle_task_termination, Terminator};

--- a/consensus/src/testing/consensus.rs
+++ b/consensus/src/testing/consensus.rs
@@ -1,7 +1,7 @@
 use crate::{
     consensus,
     runway::{NotificationIn, NotificationOut},
-    testing::{complete_oneshot, gen_config, init_log},
+    testing::{complete_oneshot, gen_config, gen_delay_config, init_log},
     units::{ControlHash, PreUnit, Unit, UnitCoord},
     Hasher, NodeIndex, SpawnHandle, Terminator,
 };
@@ -161,7 +161,7 @@ async fn agree_on_first_batch() {
 
     for node_ix in 0..n_members {
         let (tx, rx) = hub.connect(NodeIndex(node_ix));
-        let conf = gen_config(NodeIndex(node_ix), n_members.into());
+        let conf = gen_config(NodeIndex(node_ix), n_members.into(), gen_delay_config());
         let (exit_tx, exit_rx) = oneshot::channel();
         exits.push(exit_tx);
         let (batch_tx, batch_rx) = unbounded();
@@ -204,7 +204,7 @@ async fn catches_wrong_control_hash() {
     let (mut tx_in, rx_in) = unbounded();
     let (tx_out, mut rx_out) = unbounded();
 
-    let conf = gen_config(NodeIndex(node_ix), n_nodes.into());
+    let conf = gen_config(NodeIndex(node_ix), n_nodes.into(), gen_delay_config());
     let (exit_tx, exit_rx) = oneshot::channel();
     let (batch_tx, _batch_rx) = unbounded();
     let starting_round = complete_oneshot(Some(0));

--- a/consensus/src/testing/creation.rs
+++ b/consensus/src/testing/creation.rs
@@ -1,7 +1,7 @@
 use crate::{
     creation::{run, IO},
     runway::NotificationOut as GenericNotificationOut,
-    testing::gen_config,
+    testing::{gen_config, gen_delay_config},
     units::{FullUnit as GenericFullUnit, PreUnit as GenericPreUnit, Unit as GenericUnit},
     NodeCount, Receiver, Round, Sender, Terminator,
 };
@@ -89,7 +89,7 @@ fn setup_test(n_members: NodeCount) -> TestSetup {
             incoming_parents: parents_from_controller,
             outgoing_units: notifications_for_controller.clone(),
         };
-        let config = gen_config(node_ix.into(), n_members);
+        let config = gen_config(node_ix.into(), n_members, gen_delay_config());
         let (starting_round_for_consensus, starting_round) = oneshot::channel();
 
         units_for_creators.push(parents_for_creator);

--- a/consensus/src/testing/dag.rs
+++ b/consensus/src/testing/dag.rs
@@ -1,7 +1,7 @@
 use crate::{
     consensus,
     runway::{NotificationIn, NotificationOut},
-    testing::{complete_oneshot, gen_config},
+    testing::{complete_oneshot, gen_config, gen_delay_config},
     units::{ControlHash, PreUnit, Unit},
     NodeCount, NodeIndex, NodeMap, NodeSubset, Receiver, Round, Sender, SpawnHandle, Terminator,
 };
@@ -125,7 +125,7 @@ async fn run_consensus_on_dag(
     deadline_ms: u64,
 ) -> Vec<Vec<Hash64>> {
     let (feeder, rx_in, tx_out) = ConsensusDagFeeder::new(units);
-    let conf = gen_config(NodeIndex(0), n_members);
+    let conf = gen_config(NodeIndex(0), n_members, gen_delay_config());
     let (_exit_tx, exit_rx) = oneshot::channel();
     let (batch_tx, mut batch_rx) = mpsc::unbounded();
     let spawner = Spawner::new();

--- a/consensus/src/testing/mod.rs
+++ b/consensus/src/testing/mod.rs
@@ -9,8 +9,8 @@ mod dag;
 mod unreliable;
 
 use crate::{
-    run_session, Config, DelayConfig, LocalIO, Network as NetworkT, NodeCount, NodeIndex,
-    SpawnHandle, TaskHandle, Terminator,
+    create_config, run_session, Config, DelayConfig, LocalIO, Network as NetworkT, NodeCount,
+    NodeIndex, SpawnHandle, TaskHandle, Terminator,
 };
 use aleph_bft_mock::{
     Data, DataProvider, FinalizationHandler, Hasher64, Keychain, Loader, Network as MockNetwork,
@@ -38,8 +38,8 @@ pub fn complete_oneshot<T: std::fmt::Debug>(t: T) -> oneshot::Receiver<T> {
     rx
 }
 
-pub fn gen_config(node_ix: NodeIndex, n_members: NodeCount) -> Config {
-    let delay_config = DelayConfig {
+pub fn gen_delay_config() -> DelayConfig {
+    DelayConfig {
         tick_interval: Duration::from_millis(5),
         unit_rebroadcast_interval_min: Duration::from_millis(400),
         unit_rebroadcast_interval_max: Duration::from_millis(500),
@@ -55,14 +55,12 @@ pub fn gen_config(node_ix: NodeIndex, n_members: NodeCount) -> Config {
         parent_request_recipients: Arc::new(|_| 1),
         // 50, 50, 50, 50, ...
         newest_request_delay: Arc::new(|_| Duration::from_millis(50)),
-    };
-    Config {
-        node_ix,
-        session_id: 0,
-        n_members,
-        delay_config,
-        max_round: 5000,
     }
+}
+
+pub fn gen_config(node_ix: NodeIndex, n_members: NodeCount, delay_config: DelayConfig) -> Config {
+    create_config(n_members, node_ix, 0, 5000, delay_config, Duration::ZERO)
+        .expect("Should always succeed with Duration::ZERO")
 }
 
 pub struct HonestMember {
@@ -81,7 +79,7 @@ pub fn spawn_honest_member(
 ) -> HonestMember {
     let data_provider = DataProvider::new();
     let (finalization_handler, finalization_rx) = FinalizationHandler::new();
-    let config = gen_config(node_index, n_members);
+    let config = gen_config(node_index, n_members, gen_delay_config());
     let (exit_tx, exit_rx) = oneshot::channel();
     let spawner_inner = spawner;
     let unit_loader = Loader::new(units);

--- a/examples/blockchain/src/main.rs
+++ b/examples/blockchain/src/main.rs
@@ -128,12 +128,11 @@ async fn main() {
     let member_terminator = terminator.add_offspring_connection("AlephBFT-member");
     let member_handle = tokio::spawn(async move {
         let keychain = Keychain::new(args.n_members.into(), args.my_id.into());
-        let config = aleph_bft::create_config(
+        let config = aleph_bft::default_config(
             args.n_members.into(),
             args.my_id.into(),
             0,
-            None,
-            None,
+            5000,
             Duration::ZERO,
         )
         .expect("Should always succeed with Duration::ZERO");

--- a/examples/blockchain/src/main.rs
+++ b/examples/blockchain/src/main.rs
@@ -128,7 +128,15 @@ async fn main() {
     let member_terminator = terminator.add_offspring_connection("AlephBFT-member");
     let member_handle = tokio::spawn(async move {
         let keychain = Keychain::new(args.n_members.into(), args.my_id.into());
-        let config = aleph_bft::default_config(args.n_members.into(), args.my_id.into(), 0);
+        let config = aleph_bft::create_config(
+            args.n_members.into(),
+            args.my_id.into(),
+            0,
+            None,
+            None,
+            Duration::ZERO,
+        )
+        .expect("Should always succeed with Duration::ZERO");
         let backup_loader = Loader::new(vec![]);
         let backup_saver = Saver::new();
         let local_io = aleph_bft::LocalIO::new(

--- a/examples/ordering/src/main.rs
+++ b/examples/ordering/src/main.rs
@@ -116,7 +116,7 @@ async fn main() {
     let member_terminator = Terminator::create_root(exit_rx, "AlephBFT-member");
     let member_handle = tokio::spawn(async move {
         let keychain = Keychain::new(n_members, id);
-        let config = aleph_bft::create_config(n_members, id, 0, None, None, Duration::ZERO)
+        let config = aleph_bft::default_config(n_members, id, 0, 5000, Duration::ZERO)
             .expect("Should always succeed with Duration::ZERO");
         run_session(
             config,

--- a/examples/ordering/src/main.rs
+++ b/examples/ordering/src/main.rs
@@ -8,7 +8,7 @@ use dataio::{Data, DataProvider, FinalizationHandler};
 use futures::{channel::oneshot, StreamExt};
 use log::{debug, error, info};
 use network::Network;
-use std::{collections::HashMap, fs, fs::File, io, io::Write, path::Path};
+use std::{collections::HashMap, fs, fs::File, io, io::Write, path::Path, time::Duration};
 use time::{macros::format_description, OffsetDateTime};
 
 /// Example node producing linear order.
@@ -116,7 +116,8 @@ async fn main() {
     let member_terminator = Terminator::create_root(exit_rx, "AlephBFT-member");
     let member_handle = tokio::spawn(async move {
         let keychain = Keychain::new(n_members, id);
-        let config = aleph_bft::default_config(n_members, id, 0);
+        let config = aleph_bft::create_config(n_members, id, 0, None, None, Duration::ZERO)
+            .expect("Should always succeed with Duration::ZERO");
         run_session(
             config,
             local_io,
@@ -159,7 +160,7 @@ async fn main() {
         } else if count_finalized.values().all(|c| c >= &(n_data)) {
             info!("Finalized required number of items.");
             info!("Waiting 10 seconds for other nodes...");
-            tokio::time::sleep(core::time::Duration::from_secs(10)).await;
+            tokio::time::sleep(Duration::from_secs(10)).await;
             info!("Shutdown.");
             break;
         }

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -207,15 +207,8 @@ pub fn gen_delay_config() -> DelayConfig {
 }
 
 pub fn gen_config(node_ix: NodeIndex, n_members: NodeCount, delay_config: DelayConfig) -> Config {
-    create_config(
-        n_members,
-        node_ix,
-        0,
-        Some(5000),
-        Some(delay_config),
-        Duration::ZERO,
-    )
-    .expect("Should always succeed with Duration::ZERO")
+    create_config(n_members, node_ix, 0, 5000, delay_config, Duration::ZERO)
+        .expect("Should always succeed with Duration::ZERO")
 }
 
 pub fn spawn_honest_member_with_config(

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -1,6 +1,6 @@
 use aleph_bft::{
-    run_session, Config, DelayConfig, LocalIO, Network as NetworkT, NetworkData, NodeCount,
-    NodeIndex, Recipient, SpawnHandle, TaskHandle, Terminator,
+    create_config, run_session, Config, DelayConfig, LocalIO, Network as NetworkT, NetworkData,
+    NodeCount, NodeIndex, Recipient, SpawnHandle, TaskHandle, Terminator,
 };
 use aleph_bft_mock::{
     Data, DataProvider, FinalizationHandler, Hasher64, Keychain, Loader, NetworkHook,
@@ -186,8 +186,8 @@ fn init_log() {
         .try_init();
 }
 
-pub fn gen_config(node_ix: NodeIndex, n_members: NodeCount) -> Config {
-    let delay_config = DelayConfig {
+pub fn gen_delay_config() -> DelayConfig {
+    DelayConfig {
         tick_interval: Duration::from_millis(5),
         unit_rebroadcast_interval_min: Duration::from_millis(400),
         unit_rebroadcast_interval_max: Duration::from_millis(500),
@@ -203,14 +203,19 @@ pub fn gen_config(node_ix: NodeIndex, n_members: NodeCount) -> Config {
         parent_request_recipients: Arc::new(|_| 1),
         // 50, 50, 50, 50, ...
         newest_request_delay: Arc::new(|_| Duration::from_millis(50)),
-    };
-    Config {
-        node_ix,
-        session_id: 0,
-        n_members,
-        delay_config,
-        max_round: 5000,
     }
+}
+
+pub fn gen_config(node_ix: NodeIndex, n_members: NodeCount, delay_config: DelayConfig) -> Config {
+    create_config(
+        n_members,
+        node_ix,
+        0,
+        Some(5000),
+        Some(delay_config),
+        Duration::ZERO,
+    )
+    .expect("Should always succeed with Duration::ZERO")
 }
 
 pub fn spawn_honest_member_with_config(
@@ -289,7 +294,7 @@ impl NetworkDataEncoding {
     pub(crate) fn decode_from<R: Read>(
         &self,
         reader: &mut R,
-    ) -> core::result::Result<FuzzNetworkData, codec::Error> {
+    ) -> Result<FuzzNetworkData, codec::Error> {
         let mut reader = IoReader(reader);
         <FuzzNetworkData>::decode(&mut reader)
     }
@@ -409,7 +414,7 @@ async fn execute_generate_fuzz<'a, W: Write + Send + 'static>(
     let (mut router, networks) = Router::new(n_members.into(), 1.0);
     router.add_hook(spy);
 
-    let delay_config = gen_config(0.into(), n_members.into()).delay_config;
+    let delay_config = gen_delay_config();
     let spawner = Spawner::new(&delay_config);
     spawner.spawn("network", router);
 
@@ -417,7 +422,7 @@ async fn execute_generate_fuzz<'a, W: Write + Send + 'static>(
     let mut exits = Vec::new();
     for (network, _) in networks.into_iter().take(threshold) {
         let keychain = Keychain::new(NodeCount(n_members), network.index());
-        let config = gen_config(network.index(), n_members.into());
+        let config = gen_config(network.index(), n_members.into(), delay_config.clone());
         let (exit_tx, batch_rx) =
             spawn_honest_member_with_config(spawner.clone(), config, network, keychain);
         exits.push(exit_tx);
@@ -440,7 +445,8 @@ async fn execute_fuzz(
     n_members: usize,
     n_batches: Option<usize>,
 ) {
-    let config = gen_config(0.into(), n_members.into());
+    let delay_config = gen_delay_config();
+    let config = gen_config(0.into(), n_members.into(), delay_config.clone());
     let (net_exit, net_exit_rx) = oneshot::channel();
     let (playback_finished_tx, mut playback_finished_rx) = oneshot::channel();
     let finished_callback = move || {
@@ -450,7 +456,7 @@ async fn execute_fuzz(
     };
     let network = PlaybackNetwork::new(data, net_exit_rx, finished_callback);
 
-    let spawner = Spawner::new(&config.delay_config);
+    let spawner = Spawner::new(&delay_config);
     let node_index = NodeIndex(0);
     let keychain = Keychain::new(NodeCount(n_members), node_index);
     let (exit_tx, mut batch_rx) =
@@ -460,7 +466,7 @@ async fn execute_fuzz(
         if let Some(batches) = n_batches {
             (batches, true)
         } else {
-            (usize::max_value(), false)
+            (usize::MAX, false)
         }
     };
     let mut batches_count = 0;


### PR DESCRIPTION
Add a function which can be used to check whether reaching the maximum round takes large enough amount of time. The function is not called in AlephBFT as various projects which use aleph-bft may expect different delays. Instead the function is publically exposed to be called in the project which uses AlephBFT.

Tests:
* checked that `ordering` and `blockchain` examples work well
* checked that `aleph-node` (after needed changes) works with this version of AlephBFT (but turned out we also need to make `default_delay_config` public)