### PR TITLE
A0-2883: Make keychain synchronous

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-bft"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "aleph-bft-mock",
  "aleph-bft-rmc",
@@ -51,7 +51,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-bft-crypto"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "bit-vec",
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-bft-mock"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "aleph-bft-types",
  "async-trait",
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-bft-rmc"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "aleph-bft-crypto",
  "aleph-bft-mock",

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ More details are available [in the book][reference-link-implementation-details].
 - Import AlephBFT in your crate
   ```toml
   [dependencies]
-  aleph-bft = "^0.22"
+  aleph-bft = "^0.23"
   ```
 - The main entry point is the `run_session` function, which returns a Future that runs the
   consensus algorithm.

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-bft"
-version = "0.22.0"
+version = "0.23.0"
 edition = "2021"
 authors = ["Cardinal Cryptography"]
 categories = ["algorithms", "data-structures", "cryptography", "database"]

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 description = "AlephBFT is an asynchronous and Byzantine fault tolerant consensus protocol aimed at ordering arbitrary messages (transactions). It has been designed to continuously operate even in the harshest conditions: with no bounds on message-delivery delays and in the presence of malicious actors. This makes it an excellent fit for blockchain-related applications."
 
 [dependencies]
-aleph-bft-rmc = { path = "../rmc", version = "0.6" }
+aleph-bft-rmc = { path = "../rmc", version = "0.7" }
 aleph-bft-types = { path = "../types", version = "0.8" }
 anyhow = "1.0"
 async-trait = "0.1"

--- a/consensus/src/alerts/mod.rs
+++ b/consensus/src/alerts/mod.rs
@@ -290,7 +290,7 @@ impl<'a, H: Hasher, D: Data, MK: MultiKeychain> Alerter<'a, H, D, MK> {
     }
 
     /// `on_own_alert()` registers RMCs and messages but does not actually send them; make sure the returned values are forwarded to IO
-    async fn on_own_alert(
+    fn on_own_alert(
         &mut self,
         alert: Alert<H, D, MK::Signature>,
     ) -> (
@@ -300,7 +300,7 @@ impl<'a, H: Hasher, D: Data, MK: MultiKeychain> Alerter<'a, H, D, MK> {
     ) {
         let forker = alert.forker();
         self.known_forkers.insert(forker, alert.proof.clone());
-        let alert = Signed::sign(alert, self.keychain).await;
+        let alert = Signed::sign(alert, self.keychain);
         let hash = self.rmc_alert(forker, alert.clone());
         (
             AlertMessage::ForkAlert(alert.into_unchecked()),
@@ -463,7 +463,7 @@ pub(crate) async fn run<H: Hasher, D: Data, MK: MultiKeychain>(
                             }
                         }
                         Some(AlerterResponse::ForkResponse(maybe_notification, hash)) => {
-                            io.rmc.start_rmc(hash).await;
+                            io.rmc.start_rmc(hash);
                             if let Some(notification) = maybe_notification {
                                 io.send_notification_for_units(notification, &mut alerter.exiting);
                             }
@@ -478,9 +478,9 @@ pub(crate) async fn run<H: Hasher, D: Data, MK: MultiKeychain>(
             },
             alert = io.alerts_from_units.next() => match alert {
                 Some(alert) => {
-                    let (message, recipient, hash) = alerter.on_own_alert(alert.clone()).await;
+                    let (message, recipient, hash) = alerter.on_own_alert(alert.clone());
                     io.send_message_for_network(message, recipient, &mut alerter.exiting);
-                    io.rmc.start_rmc(hash).await;
+                    io.rmc.start_rmc(hash);
                 }
                 None => {
                     error!(target: "AlephBFT-alerter", "{:?} Alert stream closed.", alerter.index());
@@ -545,7 +545,7 @@ mod tests {
     }
 
     /// Fabricates proof of a fork by a particular node, given its private key.
-    async fn make_fork_proof(
+    fn make_fork_proof(
         node_id: NodeIndex,
         keychain: &Keychain,
         round: Round,
@@ -553,13 +553,13 @@ mod tests {
     ) -> TestForkProof {
         let unit_0 = full_unit(n_members, node_id, round, Some(0));
         let unit_1 = full_unit(n_members, node_id, round, Some(1));
-        let signed_unit_0 = Signed::sign(unit_0, keychain).await.into_unchecked();
-        let signed_unit_1 = Signed::sign(unit_1, keychain).await.into_unchecked();
+        let signed_unit_0 = Signed::sign(unit_0, keychain).into_unchecked();
+        let signed_unit_1 = Signed::sign(unit_1, keychain).into_unchecked();
         (signed_unit_0, signed_unit_1)
     }
 
-    #[tokio::test]
-    async fn distributes_alert_from_units() {
+    #[test]
+    fn distributes_alert_from_units() {
         let n_members = NodeCount(7);
         let own_index = NodeIndex(0);
         let forker_index = NodeIndex(6);
@@ -572,14 +572,12 @@ mod tests {
                 session_id: 0,
             },
         );
-        let fork_proof = make_fork_proof(forker_index, &forker_keychain, 0, n_members).await;
+        let fork_proof = make_fork_proof(forker_index, &forker_keychain, 0, n_members);
         let alert = Alert::new(own_index, fork_proof, vec![]);
-        let signed_alert = Signed::sign(alert.clone(), this.keychain)
-            .await
-            .into_unchecked();
+        let signed_alert = Signed::sign(alert.clone(), this.keychain).into_unchecked();
         let alert_hash = Signable::hash(&alert);
         assert_eq!(
-            this.on_own_alert(alert).await,
+            this.on_own_alert(alert),
             (
                 AlertMessage::ForkAlert(signed_alert),
                 Recipient::Everyone,
@@ -588,8 +586,8 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn reacts_to_correctly_incoming_alert() {
+    #[test]
+    fn reacts_to_correctly_incoming_alert() {
         let n_members = NodeCount(7);
         let own_index = NodeIndex(1);
         let forker_index = NodeIndex(6);
@@ -602,18 +600,18 @@ mod tests {
                 session_id: 0,
             },
         );
-        let fork_proof = make_fork_proof(forker_index, &forker_keychain, 0, n_members).await;
+        let fork_proof = make_fork_proof(forker_index, &forker_keychain, 0, n_members);
         let alert = Alert::new(own_index, fork_proof.clone(), vec![]);
         let alert_hash = Signable::hash(&alert);
-        let signed_alert = Signed::sign(alert, this.keychain).await.into_unchecked();
+        let signed_alert = Signed::sign(alert, this.keychain).into_unchecked();
         assert_eq!(
             this.on_network_alert(signed_alert),
             Some((Some(ForkingNotification::Forker(fork_proof)), alert_hash)),
         );
     }
 
-    #[tokio::test]
-    async fn asks_about_unknown_alert() {
+    #[test]
+    fn asks_about_unknown_alert() {
         let n_members = NodeCount(7);
         let own_index = NodeIndex(0);
         let alerter_index = NodeIndex(1);
@@ -628,12 +626,11 @@ mod tests {
                 session_id: 0,
             },
         );
-        let fork_proof = make_fork_proof(forker_index, &forker_keychain, 0, n_members).await;
+        let fork_proof = make_fork_proof(forker_index, &forker_keychain, 0, n_members);
         let alert = Alert::new(alerter_index, fork_proof.clone(), vec![]);
         let alert_hash = Signable::hash(&alert);
-        let signed_alert_hash = Signed::sign_with_index(alert_hash, &alerter_keychain)
-            .await
-            .into_unchecked();
+        let signed_alert_hash =
+            Signed::sign_with_index(alert_hash, &alerter_keychain).into_unchecked();
         let message =
             AlertMessage::RmcMessage(alerter_index, RmcMessage::SignedHash(signed_alert_hash));
         let response = this.on_message(message);
@@ -646,8 +643,8 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn ignores_wrong_alert() {
+    #[test]
+    fn ignores_wrong_alert() {
         let n_members = NodeCount(7);
         let own_index = NodeIndex(0);
         let alerter_index = NodeIndex(1);
@@ -666,21 +663,18 @@ mod tests {
             full_unit(n_members, alerter_index, 0, Some(0)),
             &alerter_keychain,
         )
-        .await
         .into_unchecked();
         let wrong_fork_proof = (valid_unit.clone(), valid_unit);
         let wrong_alert = Alert::new(forker_index, wrong_fork_proof.clone(), vec![]);
-        let signed_wrong_alert = Signed::sign(wrong_alert, &forker_keychain)
-            .await
-            .into_unchecked();
+        let signed_wrong_alert = Signed::sign(wrong_alert, &forker_keychain).into_unchecked();
         assert_eq!(
             this.on_message(AlertMessage::ForkAlert(signed_wrong_alert)),
             None,
         );
     }
 
-    #[tokio::test]
-    async fn responds_to_alert_queries() {
+    #[test]
+    fn responds_to_alert_queries() {
         let n_members = NodeCount(7);
         let own_index = NodeIndex(0);
         let forker_index = NodeIndex(6);
@@ -695,13 +689,11 @@ mod tests {
         );
         let alert = Alert::new(
             own_index,
-            make_fork_proof(forker_index, &forker_keychain, 0, n_members).await,
+            make_fork_proof(forker_index, &forker_keychain, 0, n_members),
             vec![],
         );
         let alert_hash = Signable::hash(&alert);
-        let signed_alert = Signed::sign(alert.clone(), &own_keychain)
-            .await
-            .into_unchecked();
+        let signed_alert = Signed::sign(alert.clone(), &own_keychain).into_unchecked();
         this.on_message(AlertMessage::ForkAlert(signed_alert.clone()));
         for i in 1..n_members.0 {
             let node_id = NodeIndex(i);
@@ -715,8 +707,8 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn notifies_only_about_multisigned_alert() {
+    #[test]
+    fn notifies_only_about_multisigned_alert() {
         let n_members = NodeCount(7);
         let own_index = NodeIndex(0);
         let other_honest_node = NodeIndex(1);
@@ -732,16 +724,13 @@ mod tests {
                 session_id: 0,
             },
         );
-        let fork_proof =
-            make_fork_proof(forker_index, &keychains[forker_index.0], 0, n_members).await;
+        let fork_proof = make_fork_proof(forker_index, &keychains[forker_index.0], 0, n_members);
         let empty_alert = Alert::new(double_committer, fork_proof.clone(), vec![]);
         let empty_alert_hash = Signable::hash(&empty_alert);
-        let signed_empty_alert = Signed::sign(empty_alert.clone(), &keychains[double_committer.0])
-            .await
-            .into_unchecked();
+        let signed_empty_alert =
+            Signed::sign(empty_alert.clone(), &keychains[double_committer.0]).into_unchecked();
         let signed_empty_alert_hash =
             Signed::sign_with_index(empty_alert_hash, &keychains[double_committer.0])
-                .await
                 .into_unchecked();
         let multisigned_empty_alert_hash = signed_empty_alert_hash
             .check(&keychains[double_committer.0])
@@ -767,12 +756,9 @@ mod tests {
         );
         let nonempty_alert_hash = Signable::hash(&nonempty_alert);
         let signed_nonempty_alert =
-            Signed::sign(nonempty_alert.clone(), &keychains[double_committer.0])
-                .await
-                .into_unchecked();
+            Signed::sign(nonempty_alert.clone(), &keychains[double_committer.0]).into_unchecked();
         let signed_nonempty_alert_hash =
             Signed::sign_with_index(nonempty_alert_hash, &keychains[double_committer.0])
-                .await
                 .into_unchecked();
         let mut multisigned_nonempty_alert_hash = signed_nonempty_alert_hash
             .check(&keychains[double_committer.0])
@@ -782,7 +768,6 @@ mod tests {
             let node_id = NodeIndex(i);
             let signed_nonempty_alert_hash =
                 Signed::sign_with_index(nonempty_alert_hash, &keychains[node_id.0])
-                    .await
                     .into_unchecked();
             multisigned_nonempty_alert_hash = multisigned_nonempty_alert_hash.add_signature(
                 signed_nonempty_alert_hash
@@ -802,8 +787,8 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn ignores_insufficiently_multisigned_alert() {
+    #[test]
+    fn ignores_insufficiently_multisigned_alert() {
         let n_members = NodeCount(7);
         let own_index = NodeIndex(0);
         let other_honest_node = NodeIndex(1);
@@ -819,13 +804,11 @@ mod tests {
                 session_id: 0,
             },
         );
-        let fork_proof =
-            make_fork_proof(forker_index, &keychains[forker_index.0], 0, n_members).await;
+        let fork_proof = make_fork_proof(forker_index, &keychains[forker_index.0], 0, n_members);
         let empty_alert = Alert::new(double_committer, fork_proof.clone(), vec![]);
         let empty_alert_hash = Signable::hash(&empty_alert);
-        let signed_empty_alert = Signed::sign(empty_alert.clone(), &keychains[double_committer.0])
-            .await
-            .into_unchecked();
+        let signed_empty_alert =
+            Signed::sign(empty_alert.clone(), &keychains[double_committer.0]).into_unchecked();
         assert_eq!(
             this.on_message(AlertMessage::ForkAlert(signed_empty_alert)),
             Some(AlerterResponse::ForkResponse(
@@ -841,12 +824,9 @@ mod tests {
         );
         let nonempty_alert_hash = Signable::hash(&nonempty_alert);
         let signed_nonempty_alert =
-            Signed::sign(nonempty_alert.clone(), &keychains[double_committer.0])
-                .await
-                .into_unchecked();
+            Signed::sign(nonempty_alert.clone(), &keychains[double_committer.0]).into_unchecked();
         let signed_nonempty_alert_hash =
             Signed::sign_with_index(nonempty_alert_hash, &keychains[double_committer.0])
-                .await
                 .into_unchecked();
         let mut multisigned_nonempty_alert_hash = signed_nonempty_alert_hash
             .check(&keychains[double_committer.0])
@@ -856,7 +836,6 @@ mod tests {
             let node_id = NodeIndex(i);
             let signed_nonempty_alert_hash =
                 Signed::sign_with_index(nonempty_alert_hash, &keychains[node_id.0])
-                    .await
                     .into_unchecked();
             multisigned_nonempty_alert_hash = multisigned_nonempty_alert_hash.add_signature(
                 signed_nonempty_alert_hash
@@ -876,8 +855,8 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn who_is_forking_ok() {
+    #[test]
+    fn who_is_forking_ok() {
         let n_members = NodeCount(7);
         let own_index = NodeIndex(0);
         let forker_index = NodeIndex(6);
@@ -890,12 +869,12 @@ mod tests {
                 session_id: 0,
             },
         );
-        let fork_proof = make_fork_proof(forker_index, &forker_keychain, 0, n_members).await;
+        let fork_proof = make_fork_proof(forker_index, &forker_keychain, 0, n_members);
         assert_eq!(this.who_is_forking(&fork_proof), Some(forker_index));
     }
 
-    #[tokio::test]
-    async fn who_is_forking_wrong_session() {
+    #[test]
+    fn who_is_forking_wrong_session() {
         let n_members = NodeCount(7);
         let own_index = NodeIndex(0);
         let forker_index = NodeIndex(6);
@@ -908,12 +887,12 @@ mod tests {
                 session_id: 1,
             },
         );
-        let fork_proof = make_fork_proof(forker_index, &forker_keychain, 0, n_members).await;
+        let fork_proof = make_fork_proof(forker_index, &forker_keychain, 0, n_members);
         assert_eq!(this.who_is_forking(&fork_proof), None);
     }
 
-    #[tokio::test]
-    async fn who_is_forking_different_creators() {
+    #[test]
+    fn who_is_forking_different_creators() {
         let n_members = NodeCount(7);
         let keychains: Vec<_> = (0..n_members.0)
             .map(|i| Keychain::new(n_members, NodeIndex(i)))
@@ -928,15 +907,15 @@ mod tests {
         let fork_proof = {
             let unit_0 = full_unit(n_members, NodeIndex(6), 0, Some(0));
             let unit_1 = full_unit(n_members, NodeIndex(5), 0, Some(0));
-            let signed_unit_0 = Signed::sign(unit_0, &keychains[6]).await.into_unchecked();
-            let signed_unit_1 = Signed::sign(unit_1, &keychains[5]).await.into_unchecked();
+            let signed_unit_0 = Signed::sign(unit_0, &keychains[6]).into_unchecked();
+            let signed_unit_1 = Signed::sign(unit_1, &keychains[5]).into_unchecked();
             (signed_unit_0, signed_unit_1)
         };
         assert_eq!(this.who_is_forking(&fork_proof), None);
     }
 
-    #[tokio::test]
-    async fn who_is_forking_different_rounds() {
+    #[test]
+    fn who_is_forking_different_rounds() {
         let n_members = NodeCount(7);
         let own_index = NodeIndex(0);
         let forker_index = NodeIndex(6);
@@ -952,33 +931,29 @@ mod tests {
         let fork_proof = {
             let unit_0 = full_unit(n_members, forker_index, 0, Some(0));
             let unit_1 = full_unit(n_members, forker_index, 1, Some(0));
-            let signed_unit_0 = Signed::sign(unit_0, &forker_keychain)
-                .await
-                .into_unchecked();
-            let signed_unit_1 = Signed::sign(unit_1, &forker_keychain)
-                .await
-                .into_unchecked();
+            let signed_unit_0 = Signed::sign(unit_0, &forker_keychain).into_unchecked();
+            let signed_unit_1 = Signed::sign(unit_1, &forker_keychain).into_unchecked();
             (signed_unit_0, signed_unit_1)
         };
         assert_eq!(this.who_is_forking(&fork_proof), None);
     }
 
-    #[tokio::test]
-    async fn alert_confirmed_out_of_the_blue() {
-        alert_confirmed(false, true).await;
+    #[test]
+    fn alert_confirmed_out_of_the_blue() {
+        alert_confirmed(false, true);
     }
 
-    #[tokio::test]
-    async fn alert_confirmed_bad_commitment() {
-        alert_confirmed(true, false).await;
+    #[test]
+    fn alert_confirmed_bad_commitment() {
+        alert_confirmed(true, false);
     }
 
-    #[tokio::test]
-    async fn alert_confirmed_correct() {
-        alert_confirmed(true, true).await;
+    #[test]
+    fn alert_confirmed_correct() {
+        alert_confirmed(true, true);
     }
 
-    async fn alert_confirmed(make_known: bool, good_commitment: bool) {
+    fn alert_confirmed(make_known: bool, good_commitment: bool) {
         let n_members = NodeCount(7);
         let own_index = NodeIndex(1);
         let forker_index = NodeIndex(6);
@@ -993,38 +968,30 @@ mod tests {
             },
         );
         let fork_proof = if good_commitment {
-            make_fork_proof(forker_index, &keychains[forker_index.0], 0, n_members).await
+            make_fork_proof(forker_index, &keychains[forker_index.0], 0, n_members)
         } else {
             let unit_0 = full_unit(n_members, forker_index, 0, Some(0));
             let unit_1 = full_unit(n_members, forker_index, 1, Some(1));
-            let signed_unit_0 = Signed::sign(unit_0, &keychains[forker_index.0])
-                .await
-                .into_unchecked();
-            let signed_unit_1 = Signed::sign(unit_1, &keychains[forker_index.0])
-                .await
-                .into_unchecked();
+            let signed_unit_0 = Signed::sign(unit_0, &keychains[forker_index.0]).into_unchecked();
+            let signed_unit_1 = Signed::sign(unit_1, &keychains[forker_index.0]).into_unchecked();
             (signed_unit_0, signed_unit_1)
         };
         let alert = Alert::new(own_index, fork_proof.clone(), vec![]);
         let alert_hash = Signable::hash(&alert);
-        let signed_alert = Signed::sign(alert, &keychains[own_index.0])
-            .await
-            .into_unchecked();
+        let signed_alert = Signed::sign(alert, &keychains[own_index.0]).into_unchecked();
         if make_known {
             this.on_network_alert(signed_alert);
         }
-        let signed_alert_hash = Signed::sign_with_index(alert_hash, &keychains[own_index.0])
-            .await
-            .into_unchecked();
+        let signed_alert_hash =
+            Signed::sign_with_index(alert_hash, &keychains[own_index.0]).into_unchecked();
         let mut multisigned_alert_hash = signed_alert_hash
             .check(&keychains[forker_index.0])
             .expect("the signature is correct")
             .into_partially_multisigned(&keychains[own_index.0]);
         for i in 1..n_members.0 - 1 {
             let node_id = NodeIndex(i);
-            let signed_alert_hash = Signed::sign_with_index(alert_hash, &keychains[node_id.0])
-                .await
-                .into_unchecked();
+            let signed_alert_hash =
+                Signed::sign_with_index(alert_hash, &keychains[node_id.0]).into_unchecked();
             multisigned_alert_hash = multisigned_alert_hash.add_signature(
                 signed_alert_hash
                     .check(&keychains[forker_index.0])

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -171,7 +171,7 @@ mod tests {
     use aleph_bft_mock::{Data, Hasher64, Keychain, PartialMultisignature, Signature};
     use codec::{Decode, Encode};
 
-    async fn test_unchecked_unit(
+    fn test_unchecked_unit(
         creator: NodeIndex,
         round: Round,
         data: Data,
@@ -182,9 +182,7 @@ mod tests {
         };
         let pu = PreUnit::new(creator, round, control_hash);
         let signable = FullUnit::new(pu, Some(data), 0);
-        Signed::sign(signable, &Keychain::new(0.into(), creator))
-            .await
-            .into_unchecked()
+        Signed::sign(signable, &Keychain::new(0.into(), creator)).into_unchecked()
     }
 
     type TestNetworkData = super::NetworkData<Hasher64, Data, Signature, PartialMultisignature>;
@@ -196,11 +194,11 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn decoding_network_data_units_new_unit() {
+    #[test]
+    fn decoding_network_data_units_new_unit() {
         use UnitMessage::NewUnit;
 
-        let uu = test_unchecked_unit(5.into(), 43, 1729).await;
+        let uu = test_unchecked_unit(5.into(), 43, 1729);
         let included_data = uu.as_signable().included_data();
         let nd = TestNetworkData::new(Units(NewUnit(uu.clone())));
         let decoded = TestNetworkData::decode(&mut &nd.encode()[..]);
@@ -243,11 +241,11 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn decoding_network_data_units_response_coord() {
+    #[test]
+    fn decoding_network_data_units_response_coord() {
         use UnitMessage::ResponseCoord;
 
-        let uu = test_unchecked_unit(5.into(), 43, 1729).await;
+        let uu = test_unchecked_unit(5.into(), 43, 1729);
         let included_data = uu.as_signable().included_data();
         let nd = TestNetworkData::new(Units(ResponseCoord(uu.clone())));
         let decoded = TestNetworkData::decode(&mut &nd.encode()[..]);
@@ -290,14 +288,14 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn decoding_network_data_units_response_parents() {
+    #[test]
+    fn decoding_network_data_units_response_parents() {
         use UnitMessage::ResponseParents;
 
         let h = 43.using_encoded(Hasher64::hash);
-        let p1 = test_unchecked_unit(5.into(), 43, 1729).await;
-        let p2 = test_unchecked_unit(13.into(), 43, 1729).await;
-        let p3 = test_unchecked_unit(17.into(), 43, 1729).await;
+        let p1 = test_unchecked_unit(5.into(), 43, 1729);
+        let p2 = test_unchecked_unit(13.into(), 43, 1729);
+        let p3 = test_unchecked_unit(17.into(), 43, 1729);
         let included_data: Vec<Data> = p1
             .as_signable()
             .included_data()
@@ -335,24 +333,22 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn decoding_network_data_alert_fork_alert() {
+    #[test]
+    fn decoding_network_data_alert_fork_alert() {
         use AlertMessage::ForkAlert;
 
         let forker = 9.into();
-        let f1 = test_unchecked_unit(forker, 10, 0).await;
-        let f2 = test_unchecked_unit(forker, 10, 1).await;
-        let lu1 = test_unchecked_unit(forker, 11, 0).await;
-        let lu2 = test_unchecked_unit(forker, 12, 0).await;
+        let f1 = test_unchecked_unit(forker, 10, 0);
+        let f2 = test_unchecked_unit(forker, 10, 1);
+        let lu1 = test_unchecked_unit(forker, 11, 0);
+        let lu2 = test_unchecked_unit(forker, 12, 0);
         let mut included_data = lu1.as_signable().included_data();
         included_data.extend(lu2.as_signable().included_data());
         let sender: NodeIndex = 7.into();
         let alert = crate::alerts::Alert::new(sender, (f1, f2), vec![lu1, lu2]);
 
         let nd = TestNetworkData::new(Alert(ForkAlert(
-            Signed::sign(alert.clone(), &Keychain::new(0.into(), sender))
-                .await
-                .into_unchecked(),
+            Signed::sign(alert.clone(), &Keychain::new(0.into(), sender)).into_unchecked(),
         )));
         let decoded = TestNetworkData::decode(&mut &nd.encode()[..]);
         assert!(decoded.is_ok(), "Bug in encode/decode for ForkAlert");

--- a/consensus/src/runway/backup.rs
+++ b/consensus/src/runway/backup.rs
@@ -299,7 +299,7 @@ mod tests {
     const NODE_ID: NodeIndex = NodeIndex(0);
     const N_MEMBERS: NodeCount = NodeCount(4);
 
-    async fn produce_units(rounds: usize, session_id: SessionId) -> Vec<Vec<UncheckedSignedUnit>> {
+    fn produce_units(rounds: usize, session_id: SessionId) -> Vec<Vec<UncheckedSignedUnit>> {
         let mut creators = creator_set(N_MEMBERS);
         let keychains: Vec<_> = (0..N_MEMBERS.0)
             .map(|id| Keychain::new(N_MEMBERS, NodeIndex(id)))
@@ -346,7 +346,7 @@ mod tests {
         units.iter().map(|u| u.encode()).collect()
     }
 
-    async fn prepare_test<'a>(
+    fn prepare_test(
         encoded_units: Vec<u8>,
     ) -> (
         impl futures::Future,
@@ -377,7 +377,7 @@ mod tests {
     #[tokio::test]
     async fn nothing_loaded_nothing_collected_succeeds() {
         let (task, loaded_unit_rx, highest_response_tx, starting_round_rx) =
-            prepare_test(Vec::new()).await;
+            prepare_test(Vec::new());
 
         let handle = tokio::spawn(async {
             task.await;
@@ -393,15 +393,11 @@ mod tests {
 
     #[tokio::test]
     async fn something_loaded_nothing_collected_succeeds() {
-        let units: Vec<_> = produce_units(5, SESSION_ID)
-            .await
-            .into_iter()
-            .flatten()
-            .collect();
+        let units: Vec<_> = produce_units(5, SESSION_ID).into_iter().flatten().collect();
         let encoded_units = encode_all(units.clone()).into_iter().flatten().collect();
 
         let (task, loaded_unit_rx, highest_response_tx, starting_round_rx) =
-            prepare_test(encoded_units).await;
+            prepare_test(encoded_units);
 
         let handle = tokio::spawn(async {
             task.await;
@@ -417,15 +413,11 @@ mod tests {
 
     #[tokio::test]
     async fn something_loaded_something_collected_succeeds() {
-        let units: Vec<_> = produce_units(5, SESSION_ID)
-            .await
-            .into_iter()
-            .flatten()
-            .collect();
+        let units: Vec<_> = produce_units(5, SESSION_ID).into_iter().flatten().collect();
         let encoded_units = encode_all(units.clone()).into_iter().flatten().collect();
 
         let (task, loaded_unit_rx, highest_response_tx, starting_round_rx) =
-            prepare_test(encoded_units).await;
+            prepare_test(encoded_units);
 
         let handle = tokio::spawn(async {
             task.await;
@@ -442,7 +434,7 @@ mod tests {
     #[tokio::test]
     async fn nothing_loaded_something_collected_fails() {
         let (task, loaded_unit_rx, highest_response_tx, starting_round_rx) =
-            prepare_test(Vec::new()).await;
+            prepare_test(Vec::new());
 
         let handle = tokio::spawn(async {
             task.await;
@@ -458,15 +450,11 @@ mod tests {
 
     #[tokio::test]
     async fn loaded_smaller_then_collected_fails() {
-        let units: Vec<_> = produce_units(3, SESSION_ID)
-            .await
-            .into_iter()
-            .flatten()
-            .collect();
+        let units: Vec<_> = produce_units(3, SESSION_ID).into_iter().flatten().collect();
         let encoded_units = encode_all(units.clone()).into_iter().flatten().collect();
 
         let (task, loaded_unit_rx, highest_response_tx, starting_round_rx) =
-            prepare_test(encoded_units).await;
+            prepare_test(encoded_units);
 
         let handle = tokio::spawn(async {
             task.await;
@@ -482,15 +470,11 @@ mod tests {
 
     #[tokio::test]
     async fn dropped_collection_fails() {
-        let units: Vec<_> = produce_units(3, SESSION_ID)
-            .await
-            .into_iter()
-            .flatten()
-            .collect();
+        let units: Vec<_> = produce_units(3, SESSION_ID).into_iter().flatten().collect();
         let encoded_units = encode_all(units.clone()).into_iter().flatten().collect();
 
         let (task, loaded_unit_rx, highest_response_tx, starting_round_rx) =
-            prepare_test(encoded_units).await;
+            prepare_test(encoded_units);
 
         let handle = tokio::spawn(async {
             task.await;
@@ -506,18 +490,14 @@ mod tests {
 
     #[tokio::test]
     async fn backup_with_corrupted_encoding_fails() {
-        let units = produce_units(5, SESSION_ID)
-            .await
-            .into_iter()
-            .flatten()
-            .collect();
+        let units = produce_units(5, SESSION_ID).into_iter().flatten().collect();
         let mut unit_encodings = encode_all(units);
         let unit2_encoding_len = unit_encodings[2].len();
         unit_encodings[2].resize(unit2_encoding_len - 1, 0); // remove the last byte
         let encoded_units = unit_encodings.into_iter().flatten().collect();
 
         let (task, loaded_unit_rx, highest_response_tx, starting_round_rx) =
-            prepare_test(encoded_units).await;
+            prepare_test(encoded_units);
         let handle = tokio::spawn(async {
             task.await;
         });
@@ -532,16 +512,12 @@ mod tests {
 
     #[tokio::test]
     async fn backup_with_missing_parent_fails() {
-        let mut units: Vec<_> = produce_units(5, SESSION_ID)
-            .await
-            .into_iter()
-            .flatten()
-            .collect();
+        let mut units: Vec<_> = produce_units(5, SESSION_ID).into_iter().flatten().collect();
         units.remove(2); // it is a parent of all units of round 3
         let encoded_units = encode_all(units).into_iter().flatten().collect();
 
         let (task, loaded_unit_rx, highest_response_tx, starting_round_rx) =
-            prepare_test(encoded_units).await;
+            prepare_test(encoded_units);
         let handle = tokio::spawn(async {
             task.await;
         });
@@ -556,17 +532,13 @@ mod tests {
 
     #[tokio::test]
     async fn backup_with_duplicate_unit_succeeds() {
-        let mut units: Vec<_> = produce_units(5, SESSION_ID)
-            .await
-            .into_iter()
-            .flatten()
-            .collect();
+        let mut units: Vec<_> = produce_units(5, SESSION_ID).into_iter().flatten().collect();
         let unit2_duplicate = units[2].clone();
         units.insert(3, unit2_duplicate);
         let encoded_units = encode_all(units.clone()).into_iter().flatten().collect();
 
         let (task, loaded_unit_rx, highest_response_tx, starting_round_rx) =
-            prepare_test(encoded_units).await;
+            prepare_test(encoded_units);
 
         let handle = tokio::spawn(async {
             task.await;
@@ -582,11 +554,11 @@ mod tests {
 
     #[tokio::test]
     async fn backup_with_units_of_one_creator_fails() {
-        let units = units_of_creator(produce_units(5, SESSION_ID).await, NodeIndex(NODE_ID.0 + 1));
+        let units = units_of_creator(produce_units(5, SESSION_ID), NodeIndex(NODE_ID.0 + 1));
         let encoded_units = encode_all(units).into_iter().flatten().collect();
 
         let (task, loaded_unit_rx, highest_response_tx, starting_round_rx) =
-            prepare_test(encoded_units).await;
+            prepare_test(encoded_units);
 
         let handle = tokio::spawn(async {
             task.await;
@@ -603,14 +575,13 @@ mod tests {
     #[tokio::test]
     async fn backup_with_wrong_session_fails() {
         let units = produce_units(5, SESSION_ID + 1)
-            .await
             .into_iter()
             .flatten()
             .collect();
         let encoded_units = encode_all(units).into_iter().flatten().collect();
 
         let (task, loaded_unit_rx, highest_response_tx, starting_round_rx) =
-            prepare_test(encoded_units).await;
+            prepare_test(encoded_units);
 
         let handle = tokio::spawn(async {
             task.await;

--- a/consensus/src/runway/backup.rs
+++ b/consensus/src/runway/backup.rs
@@ -320,8 +320,9 @@ mod tests {
 
             let mut unchecked_signed_units = Vec::with_capacity(pre_units.len());
             for ((pre_unit, _), keychain) in pre_units.into_iter().zip(keychains.iter()) {
-                unchecked_signed_units
-                    .push(preunit_to_unchecked_signed_unit(pre_unit, session_id, keychain).await)
+                unchecked_signed_units.push(preunit_to_unchecked_signed_unit(
+                    pre_unit, session_id, keychain,
+                ))
             }
 
             units_per_round.push(unchecked_signed_units);

--- a/consensus/src/runway/collection.rs
+++ b/consensus/src/runway/collection.rs
@@ -531,7 +531,7 @@ mod tests {
         let (preunit, _) = creator.create_unit(0).expect("Creation should succeed.");
         let unit = preunit_to_unchecked_signed_unit(preunit, wrong_session_id, keychain);
         let responses = create_responses(
-            keychains.iter().skip(1).zip(repeat(Some(unit.clone()))),
+            keychains.iter().skip(1).zip(repeat(Some(unit))),
             salt,
             creator_id,
         );
@@ -560,7 +560,7 @@ mod tests {
         let (preunit, _) = creator.create_unit(0).expect("Creation should succeed.");
         let unit = preunit_to_unchecked_signed_unit(preunit, session_id, &keychains[1]);
         let responses = create_responses(
-            keychains.iter().skip(1).zip(repeat(Some(unit.clone()))),
+            keychains.iter().skip(1).zip(repeat(Some(unit))),
             salt,
             creator_id,
         );

--- a/consensus/src/runway/collection.rs
+++ b/consensus/src/runway/collection.rs
@@ -345,10 +345,7 @@ mod tests {
         result
     }
 
-    async fn create_responses<
-        'a,
-        R: Iterator<Item = (&'a Keychain, Option<UncheckedSignedUnit>)>,
-    >(
+    fn create_responses<'a, R: Iterator<Item = (&'a Keychain, Option<UncheckedSignedUnit>)>>(
         presponses: R,
         salt: Salt,
         requester: NodeIndex,
@@ -356,18 +353,18 @@ mod tests {
         let mut result = Vec::new();
         for (keychain, maybe_unit) in presponses {
             let response = NewestUnitResponse::new(requester, keychain.index(), maybe_unit, salt);
-            result.push(Signed::sign(response, keychain).await.into_unchecked());
+            result.push(Signed::sign(response, keychain).into_unchecked());
         }
         result
     }
 
-    async fn preunit_to_unchecked_signed_unit(
+    fn preunit_to_unchecked_signed_unit(
         pu: PreUnit,
         session_id: SessionId,
         keychain: &Keychain,
     ) -> UncheckedSignedUnit {
         let full_unit = FullUnit::new(pu, Some(0), session_id);
-        let signed_unit = Signed::sign(full_unit, keychain).await;
+        let signed_unit = Signed::sign(full_unit, keychain);
         signed_unit.into()
     }
 
@@ -384,8 +381,8 @@ mod tests {
         assert_eq!(collection.status(), Pending);
     }
 
-    #[tokio::test]
-    async fn pending_with_too_few_messages() {
+    #[test]
+    fn pending_with_too_few_messages() {
         let n_members = NodeCount(7);
         let threshold = NodeCount(5);
         let creator_id = NodeIndex(0);
@@ -399,16 +396,15 @@ mod tests {
             keychains.iter().skip(1).take(3).zip(repeat(None)),
             salt,
             creator_id,
-        )
-        .await;
+        );
         for response in responses {
             assert_eq!(collection.on_newest_response(response), Ok(Pending));
         }
         assert_eq!(collection.status(), Pending);
     }
 
-    #[tokio::test]
-    async fn pending_with_repeated_messages() {
+    #[test]
+    fn pending_with_repeated_messages() {
         let n_members = NodeCount(7);
         let threshold = NodeCount(5);
         let creator_id = NodeIndex(0);
@@ -422,16 +418,15 @@ mod tests {
             repeat(&keychains[1]).take(43).zip(repeat(None)),
             salt,
             creator_id,
-        )
-        .await;
+        );
         for response in responses {
             assert_eq!(collection.on_newest_response(response), Ok(Pending));
         }
         assert_eq!(collection.status(), Pending);
     }
 
-    #[tokio::test]
-    async fn ready_with_just_enough_messages() {
+    #[test]
+    fn ready_with_just_enough_messages() {
         let n_members = NodeCount(7);
         let threshold = NodeCount(5);
         let creator_id = NodeIndex(0);
@@ -445,8 +440,7 @@ mod tests {
             keychains.iter().skip(1).take(4).zip(repeat(None)),
             salt,
             creator_id,
-        )
-        .await;
+        );
         for response in responses.iter().take(3) {
             assert_eq!(collection.on_newest_response(response.clone()), Ok(Pending));
         }
@@ -457,8 +451,8 @@ mod tests {
         assert_eq!(collection.status(), Ready(0));
     }
 
-    #[tokio::test]
-    async fn finished_and_higher_starting_round_with_last_message() {
+    #[test]
+    fn finished_and_higher_starting_round_with_last_message() {
         let n_members = NodeCount(7);
         let threshold = NodeCount(5);
         let creator_id = NodeIndex(0);
@@ -470,7 +464,7 @@ mod tests {
         let validator = Validator::new(session_id, *keychain, max_round, threshold);
         let (mut collection, salt) = Collection::new(keychain, &validator, threshold);
         let (preunit, _) = creator.create_unit(0).expect("Creation should succeed.");
-        let unit = preunit_to_unchecked_signed_unit(preunit, session_id, keychain).await;
+        let unit = preunit_to_unchecked_signed_unit(preunit, session_id, keychain);
         let responses = create_responses(
             keychains
                 .iter()
@@ -478,8 +472,7 @@ mod tests {
                 .zip(repeat(None).take(5).chain(once(Some(unit)))),
             salt,
             creator_id,
-        )
-        .await;
+        );
         for response in responses.iter().take(3) {
             assert_eq!(collection.on_newest_response(response.clone()), Ok(Pending));
         }
@@ -496,8 +489,8 @@ mod tests {
         assert_eq!(collection.status(), Finished(1));
     }
 
-    #[tokio::test]
-    async fn detects_salt_mismatch() {
+    #[test]
+    fn detects_salt_mismatch() {
         let n_members = NodeCount(7);
         let threshold = NodeCount(5);
         let creator_id = NodeIndex(0);
@@ -512,8 +505,7 @@ mod tests {
             keychains.iter().skip(1).zip(repeat(None)),
             other_salt,
             creator_id,
-        )
-        .await;
+        );
         for response in responses {
             assert_eq!(
                 collection.on_newest_response(response),
@@ -523,8 +515,8 @@ mod tests {
         assert_eq!(collection.status(), Pending);
     }
 
-    #[tokio::test]
-    async fn detects_invalid_unit() {
+    #[test]
+    fn detects_invalid_unit() {
         let n_members = NodeCount(7);
         let threshold = NodeCount(5);
         let creator_id = NodeIndex(0);
@@ -537,13 +529,12 @@ mod tests {
         let validator = Validator::new(session_id, *keychain, max_round, threshold);
         let (mut collection, salt) = Collection::new(keychain, &validator, threshold);
         let (preunit, _) = creator.create_unit(0).expect("Creation should succeed.");
-        let unit = preunit_to_unchecked_signed_unit(preunit, wrong_session_id, keychain).await;
+        let unit = preunit_to_unchecked_signed_unit(preunit, wrong_session_id, keychain);
         let responses = create_responses(
             keychains.iter().skip(1).zip(repeat(Some(unit.clone()))),
             salt,
             creator_id,
-        )
-        .await;
+        );
         for response in responses {
             match collection.on_newest_response(response) {
                 Err(Error::InvalidUnit(_)) => (),
@@ -553,8 +544,8 @@ mod tests {
         assert_eq!(collection.status(), Pending);
     }
 
-    #[tokio::test]
-    async fn detects_foreign_unit() {
+    #[test]
+    fn detects_foreign_unit() {
         let n_members = NodeCount(7);
         let threshold = NodeCount(5);
         let creator_id = NodeIndex(0);
@@ -567,13 +558,12 @@ mod tests {
         let validator = Validator::new(session_id, *keychain, max_round, threshold);
         let (mut collection, salt) = Collection::new(keychain, &validator, threshold);
         let (preunit, _) = creator.create_unit(0).expect("Creation should succeed.");
-        let unit = preunit_to_unchecked_signed_unit(preunit, session_id, &keychains[1]).await;
+        let unit = preunit_to_unchecked_signed_unit(preunit, session_id, &keychains[1]);
         let responses = create_responses(
             keychains.iter().skip(1).zip(repeat(Some(unit.clone()))),
             salt,
             creator_id,
-        )
-        .await;
+        );
         for response in responses {
             assert_eq!(
                 collection.on_newest_response(response),

--- a/consensus/src/runway/mod.rs
+++ b/consensus/src/runway/mod.rs
@@ -271,7 +271,7 @@ where
         self.keychain.node_count()
     }
 
-    async fn on_unit_message(&mut self, message: RunwayNotificationIn<H, D, MK::Signature>) {
+    fn on_unit_message(&mut self, message: RunwayNotificationIn<H, D, MK::Signature>) {
         match message {
             RunwayNotificationIn::NewUnit(u) => {
                 trace!(target: "AlephBFT-runway", "{:?} New unit received {:?}.", self.index(), &u);
@@ -721,7 +721,7 @@ where
                 },
 
                 event = self.unit_messages_from_network.next() => match event {
-                    Some(event) => self.on_unit_message(event).await,
+                    Some(event) => self.on_unit_message(event),
                     None => {
                         error!(target: "AlephBFT-runway", "{:?} Unit message stream closed.", index);
                         break;

--- a/consensus/src/runway/mod.rs
+++ b/consensus/src/runway/mod.rs
@@ -289,7 +289,7 @@ where
                 }
                 Request::NewestUnit(salt) => {
                     trace!(target: "AlephBFT-runway", "{:?} Newest unit request received {:?}.", self.index(), salt);
-                    self.on_request_newest(node_id, salt).await
+                    self.on_request_newest(node_id, salt)
                 }
             },
 
@@ -422,13 +422,11 @@ where
         }
     }
 
-    async fn on_request_newest(&mut self, requester: NodeIndex, salt: u64) {
+    fn on_request_newest(&mut self, requester: NodeIndex, salt: u64) {
         let unit = self.store.newest_unit(requester);
         let response = NewestUnitResponse::new(requester, self.index(), unit, salt);
 
-        let signed_response = Signed::sign(response, &self.keychain)
-            .await
-            .into_unchecked();
+        let signed_response = Signed::sign(response, &self.keychain).into_unchecked();
 
         if let Err(e) =
             self.unit_messages_for_network

--- a/consensus/src/runway/packer.rs
+++ b/consensus/src/runway/packer.rs
@@ -67,7 +67,7 @@ where
             let data = self.data_provider.get_data().await;
             debug!(target: "AlephBFT-packer", "{:?} Received data.", self.index());
             let full_unit = FullUnit::new(preunit, data, self.session_id);
-            let signed_unit = Signed::sign(full_unit, &self.keychain).await;
+            let signed_unit = Signed::sign(full_unit, &self.keychain);
             if self
                 .signed_units_for_runway
                 .unbounded_send(signed_unit)

--- a/consensus/src/testing/byzantine.rs
+++ b/consensus/src/testing/byzantine.rs
@@ -7,7 +7,6 @@ use crate::{
     Recipient, Round, SessionId, Signed, SpawnHandle, TaskHandle,
 };
 use aleph_bft_mock::{Data, Hash64, Hasher64, Keychain, NetworkHook, Router, Spawner};
-use async_trait::async_trait;
 use futures::{channel::oneshot, StreamExt};
 use log::{debug, error, trace};
 use parking_lot::Mutex;
@@ -223,7 +222,6 @@ impl AlertHook {
     }
 }
 
-#[async_trait]
 impl NetworkHook<NetworkData> for AlertHook {
     fn update_state(&mut self, data: &mut NetworkData, sender: NodeIndex, recipient: NodeIndex) {
         use crate::{alerts::AlertMessage::*, network::NetworkDataInner::*};

--- a/consensus/src/testing/byzantine.rs
+++ b/consensus/src/testing/byzantine.rs
@@ -104,14 +104,14 @@ impl<'a> MaliciousMember<'a> {
         }
     }
 
-    async fn create_if_possible(&mut self, round: Round) -> bool {
+    fn create_if_possible(&mut self, round: Round) -> bool {
         if let Some(parents) = self.pick_parents(round) {
             debug!(target: "malicious-member", "Creating a legit unit for round {}.", round);
             let control_hash = ControlHash::<Hasher64>::new(&parents);
             let new_preunit = PreUnit::<Hasher64>::new(self.node_ix, round, control_hash);
             if round != self.forking_round {
                 let full_unit = FullUnit::new(new_preunit, Some(0), self.session_id);
-                let signed_unit = Signed::sign(full_unit, self.keychain).await;
+                let signed_unit = Signed::sign(full_unit, self.keychain);
                 self.on_unit_received(signed_unit.clone());
                 self.send_legit_unit(signed_unit);
             } else {
@@ -120,7 +120,7 @@ impl<'a> MaliciousMember<'a> {
                 let mut variants = Vec::new();
                 for data in 0u32..2u32 {
                     let full_unit = FullUnit::new(new_preunit.clone(), Some(data), self.session_id);
-                    let signed = Signed::sign(full_unit, self.keychain).await;
+                    let signed = Signed::sign(full_unit, self.keychain);
                     variants.push(signed);
                 }
                 self.send_two_variants(variants[0].clone(), variants[1].clone());
@@ -155,7 +155,7 @@ impl<'a> MaliciousMember<'a> {
     pub async fn run_session(mut self, mut exit: oneshot::Receiver<()>) {
         let mut round: Round = 0;
         loop {
-            if self.create_if_possible(round).await {
+            if self.create_if_possible(round) {
                 round += 1;
             }
             tokio::select! {
@@ -225,12 +225,7 @@ impl AlertHook {
 
 #[async_trait]
 impl NetworkHook<NetworkData> for AlertHook {
-    async fn update_state(
-        &mut self,
-        data: &mut NetworkData,
-        sender: NodeIndex,
-        recipient: NodeIndex,
-    ) {
+    fn update_state(&mut self, data: &mut NetworkData, sender: NodeIndex, recipient: NodeIndex) {
         use crate::{alerts::AlertMessage::*, network::NetworkDataInner::*};
         if let crate::NetworkData(Alert(ForkAlert(_))) = data {
             *self

--- a/consensus/src/testing/unreliable.rs
+++ b/consensus/src/testing/unreliable.rs
@@ -17,14 +17,8 @@ struct CorruptPacket {
     round: Round,
 }
 
-#[async_trait]
 impl NetworkHook<NetworkData> for CorruptPacket {
-    async fn update_state(
-        &mut self,
-        data: &mut NetworkData,
-        sender: NodeIndex,
-        recipient: NodeIndex,
-    ) {
+    fn update_state(&mut self, data: &mut NetworkData, sender: NodeIndex, recipient: NodeIndex) {
         if self.recipient != recipient || self.sender != sender {
             return;
         }
@@ -33,7 +27,7 @@ impl NetworkHook<NetworkData> for CorruptPacket {
             let index = full_unit.index();
             if full_unit.round() == self.round && full_unit.creator() == self.creator {
                 let bad_keychain: BadSigning<Keychain> = Keychain::new(0.into(), index).into();
-                *us = Signed::sign(full_unit, &bad_keychain).await.into();
+                *us = Signed::sign(full_unit, &bad_keychain).into();
             }
         }
     }
@@ -48,7 +42,7 @@ struct NoteRequest {
 
 #[async_trait]
 impl NetworkHook<NetworkData> for NoteRequest {
-    async fn update_state(&mut self, data: &mut NetworkData, sender: NodeIndex, _: NodeIndex) {
+    fn update_state(&mut self, data: &mut NetworkData, sender: NodeIndex, _: NodeIndex) {
         use NetworkDataInner::Units;
         use UnitMessage::RequestCoord;
         if sender == self.sender {

--- a/consensus/src/testing/unreliable.rs
+++ b/consensus/src/testing/unreliable.rs
@@ -5,7 +5,6 @@ use crate::{
     Index, NodeCount, NodeIndex, Round, Signed, SpawnHandle,
 };
 use aleph_bft_mock::{BadSigning, Keychain, NetworkHook, Router, Spawner};
-use async_trait::async_trait;
 use futures::StreamExt;
 use parking_lot::Mutex;
 use std::sync::Arc;
@@ -40,7 +39,6 @@ struct NoteRequest {
     requested: Arc<Mutex<bool>>,
 }
 
-#[async_trait]
 impl NetworkHook<NetworkData> for NoteRequest {
     fn update_state(&mut self, data: &mut NetworkData, sender: NodeIndex, _: NodeIndex) {
         use NetworkDataInner::Units;

--- a/consensus/src/units/store.rs
+++ b/consensus/src/units/store.rs
@@ -207,7 +207,7 @@ mod tests {
     };
     use aleph_bft_mock::{Data, Hasher64, Keychain};
 
-    fn create_unit<'a>(
+    fn create_unit(
         round: Round,
         node_idx: NodeIndex,
         count: NodeCount,

--- a/consensus/src/units/store.rs
+++ b/consensus/src/units/store.rs
@@ -207,7 +207,7 @@ mod tests {
     };
     use aleph_bft_mock::{Data, Hasher64, Keychain};
 
-    async fn create_unit<'a>(
+    fn create_unit<'a>(
         round: Round,
         node_idx: NodeIndex,
         count: NodeCount,
@@ -220,11 +220,11 @@ mod tests {
             ControlHash::new(&NodeMap::with_size(count)),
         );
         let full_unit = FullUnit::new(preunit, Some(0), session_id);
-        Signed::sign(full_unit, keychain).await
+        Signed::sign(full_unit, keychain)
     }
 
-    #[tokio::test]
-    async fn mark_forker_restore_state() {
+    #[test]
+    fn mark_forker_restore_state() {
         let n_nodes = NodeCount(10);
 
         let mut store = UnitStore::<Hasher64, Data, Keychain>::new(n_nodes, 100);
@@ -237,7 +237,7 @@ mod tests {
 
         for round in 0..4 {
             for (i, keychain) in keychains.iter().enumerate() {
-                let unit = create_unit(round, NodeIndex(i), n_nodes, 0, keychain).await;
+                let unit = create_unit(round, NodeIndex(i), n_nodes, 0, keychain);
                 if i == 0 {
                     forker_hashes.push(unit.as_signable().hash());
                 }
@@ -247,7 +247,7 @@ mod tests {
 
         // Forker's units
         for round in 4..7 {
-            let unit = create_unit(round, NodeIndex(0), n_nodes, 0, &keychains[0]).await;
+            let unit = create_unit(round, NodeIndex(0), n_nodes, 0, &keychains[0]);
             forker_hashes.push(unit.as_signable().hash());
             store.add_unit(unit, false);
         }

--- a/consensus/src/units/testing.rs
+++ b/consensus/src/units/testing.rs
@@ -41,12 +41,12 @@ impl Creator {
     }
 }
 
-pub async fn preunit_to_unchecked_signed_unit(
+pub fn preunit_to_unchecked_signed_unit(
     pu: PreUnit,
     session_id: SessionId,
     keychain: &Keychain,
 ) -> UncheckedSignedUnit {
     let full_unit = FullUnit::new(pu, Some(0), session_id);
-    let signed_unit = Signed::sign(full_unit, keychain).await;
+    let signed_unit = Signed::sign(full_unit, keychain);
     signed_unit.into()
 }

--- a/consensus/src/units/validator.rs
+++ b/consensus/src/units/validator.rs
@@ -136,8 +136,8 @@ mod tests {
     type Validator = GenericValidator<Keychain>;
     type Creator = GenericCreator<Hasher64>;
 
-    #[tokio::test]
-    async fn validates_initial_unit() {
+    #[test]
+    fn validates_initial_unit() {
         let n_members = NodeCount(7);
         let threshold = NodeCount(5);
         let creator_id = NodeIndex(0);
@@ -150,15 +150,15 @@ mod tests {
         let (preunit, _) = creator
             .create_unit(round)
             .expect("Creation should succeed.");
-        let unchecked_unit = preunit_to_unchecked_signed_unit(preunit, session_id, &keychain).await;
+        let unchecked_unit = preunit_to_unchecked_signed_unit(preunit, session_id, &keychain);
         let checked_unit = validator
             .validate_unit(unchecked_unit.clone())
             .expect("Unit should validate.");
         assert_eq!(unchecked_unit, checked_unit.into());
     }
 
-    #[tokio::test]
-    async fn detects_wrong_session_id() {
+    #[test]
+    fn detects_wrong_session_id() {
         let n_members = NodeCount(7);
         let threshold = NodeCount(5);
         let creator_id = NodeIndex(0);
@@ -172,8 +172,7 @@ mod tests {
         let (preunit, _) = creator
             .create_unit(round)
             .expect("Creation should succeed.");
-        let unchecked_unit =
-            preunit_to_unchecked_signed_unit(preunit, wrong_session_id, &keychain).await;
+        let unchecked_unit = preunit_to_unchecked_signed_unit(preunit, wrong_session_id, &keychain);
         let full_unit = match validator.validate_unit(unchecked_unit.clone()) {
             Ok(_) => panic!("Validated bad unit."),
             Err(WrongSession(full_unit)) => full_unit,
@@ -182,8 +181,8 @@ mod tests {
         assert_eq!(full_unit, unchecked_unit.into_signable());
     }
 
-    #[tokio::test]
-    async fn detects_wrong_number_of_members() {
+    #[test]
+    fn detects_wrong_number_of_members() {
         let n_members = NodeCount(7);
         let n_plus_one_members = NodeCount(8);
         let threshold = NodeCount(5);
@@ -198,7 +197,7 @@ mod tests {
             .create_unit(round)
             .expect("Creation should succeed.");
         let unchecked_unit =
-            preunit_to_unchecked_signed_unit(preunit.clone(), session_id, &keychain).await;
+            preunit_to_unchecked_signed_unit(preunit.clone(), session_id, &keychain);
         let other_preunit = match validator.validate_unit(unchecked_unit) {
             Ok(_) => panic!("Validated bad unit."),
             Err(WrongNumberOfMembers(other_preunit)) => other_preunit,
@@ -207,8 +206,8 @@ mod tests {
         assert_eq!(other_preunit, preunit);
     }
 
-    #[tokio::test]
-    async fn detects_below_threshold() {
+    #[test]
+    fn detects_below_threshold() {
         let n_members = NodeCount(7);
         // This is the easiest way of testing this I can think off, but it also suggests we are
         // doing something wrong by having multiple sources for what is "threshold".
@@ -231,7 +230,7 @@ mod tests {
             .create_unit(round)
             .expect("Creation should succeed.");
         let unchecked_unit =
-            preunit_to_unchecked_signed_unit(preunit.clone(), session_id, &keychain).await;
+            preunit_to_unchecked_signed_unit(preunit.clone(), session_id, &keychain);
         let other_preunit = match validator.validate_unit(unchecked_unit) {
             Ok(_) => panic!("Validated bad unit."),
             Err(NotEnoughParents(other_preunit)) => other_preunit,
@@ -240,8 +239,8 @@ mod tests {
         assert_eq!(other_preunit, preunit);
     }
 
-    #[tokio::test]
-    async fn detects_too_high_round() {
+    #[test]
+    fn detects_too_high_round() {
         let n_members = NodeCount(7);
         let threshold = NodeCount(5);
         let creator_id = NodeIndex(0);
@@ -264,7 +263,7 @@ mod tests {
         let (preunit, _) = creator
             .create_unit(round)
             .expect("Creation should succeed.");
-        let unchecked_unit = preunit_to_unchecked_signed_unit(preunit, session_id, &keychain).await;
+        let unchecked_unit = preunit_to_unchecked_signed_unit(preunit, session_id, &keychain);
         let full_unit = match validator.validate_unit(unchecked_unit.clone()) {
             Ok(_) => panic!("Validated bad unit."),
             Err(RoundTooHigh(full_unit)) => full_unit,

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-bft-crypto"
-version = "0.6.2"
+version = "0.7.0"
 edition = "2021"
 authors = ["Cardinal Cryptography"]
 documentation = "https://docs.rs/?"

--- a/crypto/src/signature.rs
+++ b/crypto/src/signature.rs
@@ -1,5 +1,4 @@
 use crate::{Index, NodeCount, NodeIndex, NodeMap};
-use async_trait::async_trait;
 use codec::{Codec, Decode, Encode};
 use log::warn;
 use std::{fmt::Debug, hash::Hash};
@@ -18,7 +17,6 @@ impl<T: Debug + Clone + Codec + Send + Sync + Eq + 'static> Signature for T {}
 /// The meaning of sign is then to produce a signature `s` using the given private key,
 /// and `verify(msg, s, j)` is to verify whether the signature s under the message msg is
 /// correct with respect to the public key of the jth node.
-#[async_trait]
 pub trait Keychain: Index + Clone + Send + Sync + 'static {
     type Signature: Signature;
 
@@ -430,7 +428,6 @@ mod tests {
         Index, Keychain, MultiKeychain, NodeCount, NodeIndex, PartialMultisignature,
         PartiallyMultisigned, Signable, SignatureSet, Signed,
     };
-    use async_trait::async_trait;
     use codec::{Decode, Encode};
     use std::fmt::Debug;
 
@@ -460,7 +457,6 @@ mod tests {
         }
     }
 
-    #[async_trait::async_trait]
     impl<K: Keychain> Keychain for DefaultMultiKeychain<K> {
         type Signature = K::Signature;
 
@@ -545,7 +541,6 @@ mod tests {
         }
     }
 
-    #[async_trait]
     impl Keychain for TestKeychain {
         type Signature = TestSignature;
 
@@ -572,8 +567,8 @@ mod tests {
         DefaultMultiKeychain::new(keychain)
     }
 
-    #[tokio::test]
-    async fn test_valid_signatures() {
+    #[test]
+    fn test_valid_signatures() {
         let node_count: NodeCount = 7.into();
         let keychains: Vec<TestMultiKeychain> = (0_usize..node_count.0)
             .map(|i| test_multi_keychain(node_count, i.into()))
@@ -591,8 +586,8 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn test_invalid_signatures() {
+    #[test]
+    fn test_invalid_signatures() {
         let node_count: NodeCount = 1.into();
         let index: NodeIndex = 0.into();
         let keychain = test_multi_keychain(node_count, index);
@@ -607,8 +602,8 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn test_incomplete_multisignature() {
+    #[test]
+    fn test_incomplete_multisignature() {
         let msg = test_message();
         let index: NodeIndex = 0.into();
         let node_count: NodeCount = 2.into();
@@ -621,8 +616,8 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn test_multisignatures() {
+    #[test]
+    fn test_multisignatures() {
         let msg = test_message();
         let node_count: NodeCount = 7.into();
         let keychains: Vec<TestMultiKeychain> = (0..node_count.0)

--- a/docs/src/aleph_bft_api.md
+++ b/docs/src/aleph_bft_api.md
@@ -60,7 +60,7 @@ The `Keychain` trait is an abstraction for digitally signing arbitrary data and 
 ```rust
 pub trait Keychain: Index + Clone + Send + Sync + 'static {
     type Signature: Signature;
-    async fn sign(&self, msg: &[u8]) -> Self::Signature;
+    fn sign(&self, msg: &[u8]) -> Self::Signature;
     fn verify(&self, msg: &[u8], sgn: &Self::Signature, index: NodeIndex) -> bool;
 }
 ```

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -260,12 +260,7 @@ impl<W: Write> SpyingNetworkHook<W> {
 
 #[async_trait::async_trait]
 impl<W: Write + Send> NetworkHook<FuzzNetworkData> for SpyingNetworkHook<W> {
-    async fn update_state(
-        &mut self,
-        data: &mut FuzzNetworkData,
-        _: NodeIndex,
-        recipient: NodeIndex,
-    ) {
+    fn update_state(&mut self, data: &mut FuzzNetworkData, _: NodeIndex, recipient: NodeIndex) {
         if self.node == recipient {
             self.encoder.encode_into(data, &mut self.output).unwrap();
         }

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -258,7 +258,6 @@ impl<W: Write> SpyingNetworkHook<W> {
     }
 }
 
-#[async_trait::async_trait]
 impl<W: Write + Send> NetworkHook<FuzzNetworkData> for SpyingNetworkHook<W> {
     fn update_state(&mut self, data: &mut FuzzNetworkData, _: NodeIndex, recipient: NodeIndex) {
         if self.node == recipient {

--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-bft-mock"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 authors = ["Cardinal Cryptography"]
 documentation = "https://docs.rs/?"

--- a/mock/src/crypto/keychain.rs
+++ b/mock/src/crypto/keychain.rs
@@ -3,7 +3,6 @@ use aleph_bft_types::{
     Index, Keychain as KeychainT, MultiKeychain as MultiKeychainT, NodeCount, NodeIndex,
     PartialMultisignature as PartialMultisignatureT, SignatureSet,
 };
-use async_trait::async_trait;
 
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct Keychain {
@@ -33,7 +32,6 @@ impl Index for Keychain {
     }
 }
 
-#[async_trait]
 impl KeychainT for Keychain {
     type Signature = Signature;
 

--- a/mock/src/crypto/keychain.rs
+++ b/mock/src/crypto/keychain.rs
@@ -41,7 +41,7 @@ impl KeychainT for Keychain {
         self.count
     }
 
-    async fn sign(&self, msg: &[u8]) -> Self::Signature {
+    fn sign(&self, msg: &[u8]) -> Self::Signature {
         Signature::new(msg.to_vec(), self.index)
     }
 

--- a/mock/src/crypto/wrappers.rs
+++ b/mock/src/crypto/wrappers.rs
@@ -2,7 +2,6 @@ use crate::crypto::{PartialMultisignature, Signature};
 use aleph_bft_types::{
     Index, Keychain as KeychainT, MultiKeychain as MultiKeychainT, NodeCount, NodeIndex,
 };
-use async_trait::async_trait;
 use codec::{Decode, Encode};
 use std::fmt::Debug;
 
@@ -34,19 +33,18 @@ impl<T: MK> Index for BadSigning<T> {
     }
 }
 
-#[async_trait]
 impl<T: MK> KeychainT for BadSigning<T> {
     type Signature = T::Signature;
+
+    fn node_count(&self) -> NodeCount {
+        self.0.node_count()
+    }
 
     fn sign(&self, msg: &[u8]) -> Self::Signature {
         let signature = self.0.sign(msg);
         let mut msg = b"BAD".to_vec();
         msg.extend(signature.msg().clone());
         Signature::new(msg, signature.index())
-    }
-
-    fn node_count(&self) -> NodeCount {
-        self.0.node_count()
     }
 
     fn verify(&self, msg: &[u8], sgn: &Self::Signature, index: NodeIndex) -> bool {

--- a/mock/src/crypto/wrappers.rs
+++ b/mock/src/crypto/wrappers.rs
@@ -38,8 +38,8 @@ impl<T: MK> Index for BadSigning<T> {
 impl<T: MK> KeychainT for BadSigning<T> {
     type Signature = T::Signature;
 
-    async fn sign(&self, msg: &[u8]) -> Self::Signature {
-        let signature = self.0.sign(msg).await;
+    fn sign(&self, msg: &[u8]) -> Self::Signature {
+        let signature = self.0.sign(msg);
         let mut msg = b"BAD".to_vec();
         msg.extend(signature.msg().clone());
         Signature::new(msg, signature.index())

--- a/rmc/Cargo.toml
+++ b/rmc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-bft-rmc"
-version = "0.6.2"
+version = "0.7.0"
 edition = "2021"
 authors = ["Cardinal Cryptography"]
 categories = ["algorithms", "cryptography"]

--- a/rmc/Cargo.toml
+++ b/rmc/Cargo.toml
@@ -13,7 +13,7 @@ readme = "./README.md"
 description = "Reliable MultiCast - a primitive for Reliable Broadcast protocol."
 
 [dependencies]
-aleph-bft-crypto = { path = "../crypto", version = "0.6" }
+aleph-bft-crypto = { path = "../crypto", version = "0.7" }
 async-trait = "0.1"
 codec = { package = "parity-scale-codec", version = "3.0", default-features = false, features = ["derive"] }
 futures = "0.3"

--- a/rmc/src/lib.rs
+++ b/rmc/src/lib.rs
@@ -216,9 +216,9 @@ impl<'a, H: Signable + Hash + Eq + Clone + Debug, MK: MultiKeychain> ReliableMul
     }
 
     /// Initiate a new instance of RMC for `hash`.
-    pub async fn start_rmc(&mut self, hash: H) {
+    pub fn start_rmc(&mut self, hash: H) {
         debug!(target: "AlephBFT-rmc", "starting rmc for {:?}", hash);
-        let signed_hash = Signed::sign_with_index(hash, self.keychain).await;
+        let signed_hash = Signed::sign_with_index(hash, self.keychain);
 
         let message = Message::SignedHash(signed_hash.into_unchecked());
         self.handle_message(message.clone());
@@ -456,7 +456,7 @@ mod tests {
 
         let hash: Signable = "56".into();
         for i in 0..node_count.0 {
-            data.rmcs[i].start_rmc(hash.clone()).await;
+            data.rmcs[i].start_rmc(hash.clone());
         }
 
         let hashes = data.collect_multisigned_hashes(node_count.0).await;
@@ -478,7 +478,7 @@ mod tests {
 
         let hash: Signable = "56".into();
         for i in 0..node_count.0 {
-            data.rmcs[i].start_rmc(hash.clone()).await;
+            data.rmcs[i].start_rmc(hash.clone());
         }
 
         let hashes = data.collect_multisigned_hashes(node_count.0).await;
@@ -503,7 +503,7 @@ mod tests {
         let threshold = (2 * node_count.0 + 1) / 3;
         let hash: Signable = "56".into();
         for i in 0..threshold {
-            data.rmcs[i].start_rmc(hash.clone()).await;
+            data.rmcs[i].start_rmc(hash.clone());
         }
 
         let hashes = data.collect_multisigned_hashes(node_count.0).await;
@@ -525,14 +525,11 @@ mod tests {
         let bad_hash: Signable = "65".into();
         let bad_keychain: BadSigning<Keychain> = Keychain::new(node_count, 0.into()).into();
         let bad_msg = TestMessage::SignedHash(
-            Signed::sign_with_index(bad_hash.clone(), &bad_keychain)
-                .await
-                .into(),
+            Signed::sign_with_index(bad_hash.clone(), &bad_keychain).into(),
         );
         data.network.broadcast_message(bad_msg);
         let bad_msg = TestMessage::MultisignedHash(
             Signed::sign_with_index(bad_hash.clone(), &bad_keychain)
-                .await
                 .into_partially_multisigned(&bad_keychain)
                 .into_unchecked(),
         );
@@ -540,7 +537,7 @@ mod tests {
 
         let hash: Signable = "56".into();
         for i in 0..node_count.0 {
-            data.rmcs[i].start_rmc(hash.clone()).await;
+            data.rmcs[i].start_rmc(hash.clone());
         }
 
         let hashes = data.collect_multisigned_hashes(node_count.0).await;

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -11,7 +11,7 @@ readme = "./README.md"
 description = "Traits that need to be implemented by the user of the aleph-bft package."
 
 [dependencies]
-aleph-bft-crypto = { path = "../crypto", version = "0.6" }
+aleph-bft-crypto = { path = "../crypto", version = "0.7" }
 async-trait = "0.1"
 codec = { package = "parity-scale-codec", version = "3.0", default-features = false, features = ["derive"] }
 futures = "0.3"


### PR DESCRIPTION
The general change was to make `sign(...)` in `crypto/signature::Keychain` synchronous. 
Removal of 1 `async` keyword caused all the other changes... The other changes included:
* removal of `async` from other functions
* removal of `await` in function calls which were no longer `async`
* changing `#[tokio::test]` to `#[test]` if a test was no longer `async`
* removal of one `#[async_trait]`
* possibly some other minor stuff.