### PR TITLE
A0-544: Alert backup preparation

### DIFF
--- a/consensus/src/alerts/service.rs
+++ b/consensus/src/alerts/service.rs
@@ -2,7 +2,8 @@ use crate::{
     alerts::{
         handler::Handler, Alert, AlertMessage, AlerterResponse, ForkingNotification, NetworkMessage,
     },
-    Data, Hasher, MultiKeychain, Multisigned, NodeCount, Receiver, Recipient, Sender, Terminator,
+    runway::BackupItem,
+    Data, Hasher, MultiKeychain, NodeCount, Receiver, Recipient, Sender, Terminator,
 };
 use aleph_bft_rmc::{DoublingDelayScheduler, Message as RmcMessage, ReliableMulticast};
 use futures::{channel::mpsc, FutureExt, StreamExt};
@@ -20,6 +21,8 @@ pub struct Service<H: Hasher, D: Data, MK: MultiKeychain> {
     messages_for_rmc: Sender<RmcMessage<H::Hash, MK::Signature, MK::PartialMultisignature>>,
     messages_from_rmc: Receiver<RmcMessage<H::Hash, MK::Signature, MK::PartialMultisignature>>,
     keychain: MK,
+    items_for_backup: Sender<BackupItem<H, D, MK>>,
+    responses_from_backup: Receiver<BackupItem<H, D, MK>>,
     exiting: bool,
 }
 
@@ -31,6 +34,8 @@ impl<H: Hasher, D: Data, MK: MultiKeychain> Service<H, D, MK> {
         notifications_for_units: Sender<ForkingNotification<H, D, MK::Signature>>,
         alerts_from_units: Receiver<Alert<H, D, MK::Signature>>,
         n_members: NodeCount,
+        items_for_backup: Sender<BackupItem<H, D, MK>>,
+        responses_from_backup: Receiver<BackupItem<H, D, MK>>,
     ) -> Service<H, D, MK> {
         let (messages_for_rmc, messages_from_us) = mpsc::unbounded();
         let (messages_for_us, messages_from_rmc) = mpsc::unbounded();
@@ -52,6 +57,8 @@ impl<H: Hasher, D: Data, MK: MultiKeychain> Service<H, D, MK> {
             messages_for_rmc,
             messages_from_rmc,
             keychain,
+            items_for_backup,
+            responses_from_backup,
             exiting: false,
         }
     }
@@ -110,7 +117,7 @@ impl<H: Hasher, D: Data, MK: MultiKeychain> Service<H, D, MK> {
     ) {
         match handler.on_message(message) {
             Ok(Some(AlerterResponse::ForkAlert(alert, recipient))) => {
-                self.send_message_for_network(AlertMessage::ForkAlert(alert), recipient);
+                self.send_item_to_backup(BackupItem::NetworkAlert(alert, recipient));
             }
             Ok(Some(AlerterResponse::AlertRequest(hash, peer))) => {
                 let message = AlertMessage::AlertRequest(self.keychain.index(), hash);
@@ -137,31 +144,36 @@ impl<H: Hasher, D: Data, MK: MultiKeychain> Service<H, D, MK> {
         }
     }
 
-    fn handle_alert_from_runway(
+    fn handle_response_from_backup(
         &mut self,
         handler: &mut Handler<H, D, MK>,
-        alert: Alert<H, D, MK::Signature>,
+        response: BackupItem<H, D, MK>,
     ) {
-        let (message, recipient, hash) = handler.on_own_alert(alert);
-        self.send_message_for_network(message, recipient);
-        self.rmc.start_rmc(hash);
+        match response {
+            BackupItem::OwnAlert(alert) => {
+                let (message, recipient, hash) = handler.on_own_alert(alert);
+                self.send_message_for_network(message, recipient);
+                self.rmc.start_rmc(hash);
+            }
+            BackupItem::NetworkAlert(alert, recipient) => {
+                self.send_message_for_network(AlertMessage::ForkAlert(alert), recipient);
+            }
+            BackupItem::MultiSignature(multisigned) => match handler.alert_confirmed(multisigned) {
+                Ok(notification) => self.send_notification_for_units(notification),
+                Err(error) => warn!(target: LOG_TARGET, "{}", error),
+            },
+            _ => {}
+        }
     }
 
-    fn handle_message_from_rmc(
-        &mut self,
-        message: RmcMessage<H::Hash, MK::Signature, MK::PartialMultisignature>,
-    ) {
-        self.rmc_message_to_network(message)
-    }
-
-    fn handle_multisigned(
-        &mut self,
-        handler: &mut Handler<H, D, MK>,
-        multisigned: Multisigned<H::Hash, MK>,
-    ) {
-        match handler.alert_confirmed(multisigned) {
-            Ok(notification) => self.send_notification_for_units(notification),
-            Err(error) => warn!(target: LOG_TARGET, "{}", error),
+    fn send_item_to_backup(&mut self, item: BackupItem<H, D, MK>) {
+        if self.items_for_backup.unbounded_send(item).is_err() {
+            warn!(
+                target: LOG_TARGET,
+                "{:?} Channel for passing items to backup was closed",
+                self.keychain.index()
+            );
+            self.exiting = true;
         }
     }
 
@@ -176,20 +188,27 @@ impl<H: Hasher, D: Data, MK: MultiKeychain> Service<H, D, MK> {
                     }
                 },
                 alert = self.alerts_from_units.next() => match alert {
-                    Some(alert) => self.handle_alert_from_runway(&mut handler, alert),
+                    Some(alert) => self.send_item_to_backup(BackupItem::OwnAlert(alert)),
                     None => {
                         error!(target: LOG_TARGET, "{:?} Alert stream closed.", self.keychain.index());
                         break;
                     }
                 },
                 message = self.messages_from_rmc.next() => match message {
-                    Some(message) => self.handle_message_from_rmc(message),
+                    Some(message) => self.rmc_message_to_network(message),
                     None => {
                         error!(target: LOG_TARGET, "{:?} RMC message stream closed.", self.keychain.index());
                         break;
                     }
                 },
-                multisigned = self.rmc.next_multisigned_hash().fuse() => self.handle_multisigned(&mut handler, multisigned),
+                multisigned = self.rmc.next_multisigned_hash().fuse() => self.send_item_to_backup(BackupItem::MultiSignature(multisigned)),
+                response = self.responses_from_backup.next() => match response {
+                    Some(item) => self.handle_response_from_backup(&mut handler, item),
+                    None => {
+                        error!(target: LOG_TARGET, "Receiver of responses from backup closed");
+                        break;
+                    }
+                },
                 _ = terminator.get_exit().fuse() => {
                     debug!(target: LOG_TARGET, "{:?} received exit signal", self.keychain.index());
                     self.exiting = true;

--- a/consensus/src/member.rs
+++ b/consensus/src/member.rs
@@ -422,10 +422,10 @@ where
 
     /// Most tasks use `requests_interval` (see [crate::DelayConfig]) as their delay.
     ///
-    /// The first exception is [Task::UnitBroadcast] - this one picks a random delay between
+    /// The first exception is [UnitBroadcast] - this one picks a random delay between
     /// `unit_rebroadcast_interval_min` and `unit_rebroadcast_interval_max`.
     ///
-    /// The other exception is [Task::CoordRequest] - this one uses the configurable
+    /// The other exception is [CoordRequest] - this one uses the configurable
     /// `coord_request_delay` schedule.
     fn delay(&self, task: &Task<H, D, S>, counter: usize) -> Duration {
         match task {
@@ -577,7 +577,7 @@ pub async fn run_session<
     UL: Read + Send + Sync + 'static,
     N: Network<NetworkData<H, D, MK::Signature, MK::PartialMultisignature>> + 'static,
     SH: SpawnHandle,
-    MK: MultiKeychain + Debug,
+    MK: MultiKeychain,
 >(
     config: Config,
     local_io: LocalIO<D, DP, FH, US, UL>,

--- a/consensus/src/member.rs
+++ b/consensus/src/member.rs
@@ -577,7 +577,7 @@ pub async fn run_session<
     UL: Read + Send + Sync + 'static,
     N: Network<NetworkData<H, D, MK::Signature, MK::PartialMultisignature>> + 'static,
     SH: SpawnHandle,
-    MK: MultiKeychain,
+    MK: MultiKeychain + Debug,
 >(
     config: Config,
     local_io: LocalIO<D, DP, FH, US, UL>,

--- a/consensus/src/runway/mod.rs
+++ b/consensus/src/runway/mod.rs
@@ -873,7 +873,7 @@ pub(crate) async fn run<H, D, US, UL, MK, DP, FH, SH>(
     UL: Read + Send + Sync + 'static,
     DP: DataProvider<D>,
     FH: FinalizationHandler<D>,
-    MK: MultiKeychain + Debug,
+    MK: MultiKeychain,
     SH: SpawnHandle,
 {
     let (tx_consensus, consensus_stream) = mpsc::unbounded();
@@ -929,7 +929,7 @@ pub(crate) async fn run<H, D, US, UL, MK, DP, FH, SH>(
 
     let (backup_items_for_saver, incoming_backup_items) = mpsc::unbounded();
     let (backup_units_for_runway, backup_units_from_saver) = mpsc::unbounded();
-    let (backup_items_for_alerter, _backup_items_from_alerter) = mpsc::unbounded();
+    let (backup_items_for_alerter, _backup_items_from_alerter) = mpsc::unbounded(); // todo: make use of backup in alerter
 
     let backup_saver_terminator = terminator.add_offspring_connection("AlephBFT-backup-saver");
     let backup_saver_handle = spawn_handle.spawn_essential("runway/backup_saver", async move {

--- a/consensus/src/testing/alerts.rs
+++ b/consensus/src/testing/alerts.rs
@@ -215,6 +215,7 @@ impl TestCase {
         let (alerts_for_alerter, alerts_from_units) = mpsc::unbounded();
         let (exit_alerter, exit) = oneshot::channel();
         let n_members = keychain.node_count();
+        let (dummy_backup_tx, dummy_backup_rx) = mpsc::unbounded();
 
         let mut alerter_service = Service::new(
             keychain,
@@ -223,6 +224,8 @@ impl TestCase {
             notifications_for_units,
             alerts_from_units,
             n_members,
+            dummy_backup_tx,
+            dummy_backup_rx, // todo: include the actual backup service in the test
         );
         let alerter_handler = Handler::new(
             keychain,

--- a/consensus/src/testing/crash_recovery.rs
+++ b/consensus/src/testing/crash_recovery.rs
@@ -1,9 +1,10 @@
 use crate::{
+    runway::BackupItem,
     testing::{init_log, spawn_honest_member, HonestMember, Network, ReconnectSender},
-    units::{UncheckedSignedUnit, UnitCoord},
+    units::UnitCoord,
     NodeCount, NodeIndex, SpawnHandle, TaskHandle,
 };
-use aleph_bft_mock::{Data, Hasher64, Router, Signature, Spawner};
+use aleph_bft_mock::{Data, Hasher64, Keychain, Router, Spawner};
 use codec::Decode;
 use futures::{
     channel::{mpsc, oneshot},
@@ -129,7 +130,11 @@ fn verify_backup(buf: &mut &[u8]) -> HashSet<UnitCoord> {
     let mut already_saved = HashSet::new();
 
     while !buf.is_empty() {
-        let unit = UncheckedSignedUnit::<Hasher64, Data, Signature>::decode(buf).unwrap();
+        let item = BackupItem::<Hasher64, Data, Keychain>::decode(buf).unwrap();
+        let unit = match item {
+            BackupItem::Unit(unit) => unit,
+            _ => continue,
+        };
         let full_unit = unit.as_signable();
         let coord = full_unit.coord();
         let parent_ids = &full_unit.as_pre_unit().control_hash().parents_mask;


### PR DESCRIPTION
Adjust `backup` to be able to store not only units (`UncheckedSignedUnit`) but also objects of type `Alert` and `Multisigned`. This is implemented by introducing an enum `BackupItem` which consists of variants which corresponds to the above types.

There is a single receiver of `BackupItem` in `backup::run_saving_mechanism`. `runway` and `alerter` should both have a sender which leads to this receiver in `backup`.

Currently no saving mechanism is implemented for `alerter`, this pr only introduces the new structure of `BackupItem` and adjustments to `backup` and `runway` caused by it.