### PR TITLE
A0-544: prepare alerts backup

### DIFF
--- a/consensus/src/member.rs
+++ b/consensus/src/member.rs
@@ -422,10 +422,10 @@ where
 
     /// Most tasks use `requests_interval` (see [crate::DelayConfig]) as their delay.
     ///
-    /// The first exception is [Task::UnitBroadcast] - this one picks a random delay between
+    /// The first exception is [UnitBroadcast] - this one picks a random delay between
     /// `unit_rebroadcast_interval_min` and `unit_rebroadcast_interval_max`.
     ///
-    /// The other exception is [Task::CoordRequest] - this one uses the configurable
+    /// The other exception is [CoordRequest] - this one uses the configurable
     /// `coord_request_delay` schedule.
     fn delay(&self, task: &Task<H, D, S>, counter: usize) -> Duration {
         match task {
@@ -577,7 +577,7 @@ pub async fn run_session<
     UL: Read + Send + Sync + 'static,
     N: Network<NetworkData<H, D, MK::Signature, MK::PartialMultisignature>> + 'static,
     SH: SpawnHandle,
-    MK: MultiKeychain + Debug,
+    MK: MultiKeychain,
 >(
     config: Config,
     local_io: LocalIO<D, DP, FH, US, UL>,

--- a/consensus/src/member.rs
+++ b/consensus/src/member.rs
@@ -577,7 +577,7 @@ pub async fn run_session<
     UL: Read + Send + Sync + 'static,
     N: Network<NetworkData<H, D, MK::Signature, MK::PartialMultisignature>> + 'static,
     SH: SpawnHandle,
-    MK: MultiKeychain,
+    MK: MultiKeychain + Debug,
 >(
     config: Config,
     local_io: LocalIO<D, DP, FH, US, UL>,

--- a/consensus/src/runway/mod.rs
+++ b/consensus/src/runway/mod.rs
@@ -873,7 +873,7 @@ pub(crate) async fn run<H, D, US, UL, MK, DP, FH, SH>(
     UL: Read + Send + Sync + 'static,
     DP: DataProvider<D>,
     FH: FinalizationHandler<D>,
-    MK: MultiKeychain + Debug,
+    MK: MultiKeychain,
     SH: SpawnHandle,
 {
     let (tx_consensus, consensus_stream) = mpsc::unbounded();
@@ -929,7 +929,7 @@ pub(crate) async fn run<H, D, US, UL, MK, DP, FH, SH>(
 
     let (backup_items_for_saver, incoming_backup_items) = mpsc::unbounded();
     let (backup_units_for_runway, backup_units_from_saver) = mpsc::unbounded();
-    let (backup_items_for_alerter, _backup_items_from_alerter) = mpsc::unbounded();
+    let (backup_items_for_alerter, _backup_items_from_alerter) = mpsc::unbounded(); // todo: make use of backup in alerter
 
     let backup_saver_terminator = terminator.add_offspring_connection("AlephBFT-backup-saver");
     let backup_saver_handle = spawn_handle.spawn_essential("runway/backup_saver", async move {

--- a/consensus/src/testing/crash_recovery.rs
+++ b/consensus/src/testing/crash_recovery.rs
@@ -1,9 +1,10 @@
 use crate::{
+    runway::BackupItem,
     testing::{init_log, spawn_honest_member, HonestMember, Network, ReconnectSender},
-    units::{UncheckedSignedUnit, UnitCoord},
+    units::UnitCoord,
     NodeCount, NodeIndex, SpawnHandle, TaskHandle,
 };
-use aleph_bft_mock::{Data, Hasher64, Router, Signature, Spawner};
+use aleph_bft_mock::{Data, Hasher64, Keychain, Router, Spawner};
 use codec::Decode;
 use futures::{
     channel::{mpsc, oneshot},
@@ -129,7 +130,11 @@ fn verify_backup(buf: &mut &[u8]) -> HashSet<UnitCoord> {
     let mut already_saved = HashSet::new();
 
     while !buf.is_empty() {
-        let unit = UncheckedSignedUnit::<Hasher64, Data, Signature>::decode(buf).unwrap();
+        let item = BackupItem::<Hasher64, Data, Keychain>::decode(buf).unwrap();
+        let unit = match item {
+            BackupItem::Unit(unit) => unit,
+            _ => continue,
+        };
         let full_unit = unit.as_signable();
         let coord = full_unit.coord();
         let parent_ids = &full_unit.as_pre_unit().control_hash().parents_mask;


### PR DESCRIPTION
Introduce `BackupItem` - an enum which encapsulates different types of data written to backup. Briefly, backup is now prepared to contain:
* units
* own alerts
* network alerts
* multisigs

The split between own and network alerts is made because we want to perform different steps for them after having them saved in the backup.

Adding `BackupItem` required to adjust runway and test cases for backup.

In this pr, alerter doesn't interact with the backup yet. 