### PR TITLE
A0-544: Alerts backup saving

### DIFF
--- a/consensus/src/alerts/mod.rs
+++ b/consensus/src/alerts/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
-    units::UncheckedSignedUnit, Data, Hasher, Index, Keychain, MultiKeychain, NodeCount, NodeIndex,
-    PartialMultisignature, Recipient, SessionId, Signable, Signature, UncheckedSigned,
+    units::UncheckedSignedUnit, Data, Hasher, Index, Keychain, MultiKeychain, NodeIndex,
+    PartialMultisignature, Recipient, Signable, Signature, UncheckedSigned,
 };
 use aleph_bft_rmc::Message as RmcMessage;
 use codec::{Decode, Encode};
@@ -154,10 +154,4 @@ pub enum AlerterResponse<H: Hasher, D: Data, S: Signature, MS: PartialMultisigna
 pub enum ForkingNotification<H: Hasher, D: Data, S: Signature> {
     Forker(ForkProof<H, D, S>),
     Units(Vec<UncheckedSignedUnit<H, D, S>>),
-}
-
-#[derive(Clone, Eq, PartialEq, Hash, Debug, Default)]
-pub struct AlertConfig {
-    pub n_members: NodeCount,
-    pub session_id: SessionId,
 }

--- a/consensus/src/alerts/service.rs
+++ b/consensus/src/alerts/service.rs
@@ -3,7 +3,7 @@ use crate::{
         handler::Handler, Alert, AlertMessage, AlerterResponse, ForkingNotification, NetworkMessage,
     },
     runway::BackupItem,
-    Data, Hasher, MultiKeychain, NodeCount, Receiver, Recipient, Sender, Terminator,
+    Data, Hasher, MultiKeychain, Receiver, Recipient, Sender, Terminator,
 };
 use aleph_bft_rmc::{DoublingDelayScheduler, Message as RmcMessage, ReliableMulticast};
 use futures::{channel::mpsc, FutureExt, StreamExt};
@@ -33,7 +33,6 @@ impl<H: Hasher, D: Data, MK: MultiKeychain> Service<H, D, MK> {
         messages_from_network: Receiver<NetworkMessage<H, D, MK>>,
         notifications_for_units: Sender<ForkingNotification<H, D, MK::Signature>>,
         alerts_from_units: Receiver<Alert<H, D, MK::Signature>>,
-        n_members: NodeCount,
         items_for_backup: Sender<BackupItem<H, D, MK>>,
         responses_from_backup: Receiver<BackupItem<H, D, MK>>,
     ) -> Service<H, D, MK> {
@@ -44,7 +43,6 @@ impl<H: Hasher, D: Data, MK: MultiKeychain> Service<H, D, MK> {
             messages_from_us,
             messages_for_us,
             keychain.clone(),
-            n_members,
             DoublingDelayScheduler::new(time::Duration::from_millis(500)),
         );
 

--- a/consensus/src/alerts/service.rs
+++ b/consensus/src/alerts/service.rs
@@ -2,7 +2,8 @@ use crate::{
     alerts::{
         handler::Handler, Alert, AlertMessage, AlerterResponse, ForkingNotification, NetworkMessage,
     },
-    Data, Hasher, MultiKeychain, Multisigned, NodeCount, Receiver, Recipient, Sender, Terminator,
+    runway::BackupItem,
+    Data, Hasher, MultiKeychain, NodeCount, Receiver, Recipient, Sender, Terminator,
 };
 use aleph_bft_rmc::{DoublingDelayScheduler, Message as RmcMessage, ReliableMulticast};
 use futures::{channel::mpsc, FutureExt, StreamExt};
@@ -20,6 +21,8 @@ pub struct Service<H: Hasher, D: Data, MK: MultiKeychain> {
     messages_for_rmc: Sender<RmcMessage<H::Hash, MK::Signature, MK::PartialMultisignature>>,
     messages_from_rmc: Receiver<RmcMessage<H::Hash, MK::Signature, MK::PartialMultisignature>>,
     keychain: MK,
+    items_for_backup: Sender<BackupItem<H, D, MK>>,
+    responses_from_backup: Receiver<BackupItem<H, D, MK>>,
     exiting: bool,
 }
 
@@ -31,6 +34,8 @@ impl<H: Hasher, D: Data, MK: MultiKeychain> Service<H, D, MK> {
         notifications_for_units: Sender<ForkingNotification<H, D, MK::Signature>>,
         alerts_from_units: Receiver<Alert<H, D, MK::Signature>>,
         n_members: NodeCount,
+        items_for_backup: Sender<BackupItem<H, D, MK>>,
+        responses_from_backup: Receiver<BackupItem<H, D, MK>>,
     ) -> Service<H, D, MK> {
         let (messages_for_rmc, messages_from_us) = mpsc::unbounded();
         let (messages_for_us, messages_from_rmc) = mpsc::unbounded();
@@ -52,6 +57,8 @@ impl<H: Hasher, D: Data, MK: MultiKeychain> Service<H, D, MK> {
             messages_for_rmc,
             messages_from_rmc,
             keychain,
+            items_for_backup,
+            responses_from_backup,
             exiting: false,
         }
     }
@@ -110,7 +117,7 @@ impl<H: Hasher, D: Data, MK: MultiKeychain> Service<H, D, MK> {
     ) {
         match handler.on_message(message) {
             Ok(Some(AlerterResponse::ForkAlert(alert, recipient))) => {
-                self.send_message_for_network(AlertMessage::ForkAlert(alert), recipient);
+                self.send_item_to_backup(BackupItem::NetworkAlert(alert, recipient));
             }
             Ok(Some(AlerterResponse::AlertRequest(hash, peer))) => {
                 let message = AlertMessage::AlertRequest(self.keychain.index(), hash);
@@ -137,31 +144,36 @@ impl<H: Hasher, D: Data, MK: MultiKeychain> Service<H, D, MK> {
         }
     }
 
-    fn handle_alert_from_runway(
+    fn handle_response_from_backup(
         &mut self,
         handler: &mut Handler<H, D, MK>,
-        alert: Alert<H, D, MK::Signature>,
+        response: BackupItem<H, D, MK>,
     ) {
-        let (message, recipient, hash) = handler.on_own_alert(alert);
-        self.send_message_for_network(message, recipient);
-        self.rmc.start_rmc(hash);
+        match response {
+            BackupItem::OwnAlert(alert) => {
+                let (message, recipient, hash) = handler.on_own_alert(alert);
+                self.send_message_for_network(message, recipient);
+                self.rmc.start_rmc(hash);
+            }
+            BackupItem::NetworkAlert(alert, recipient) => {
+                self.send_message_for_network(AlertMessage::ForkAlert(alert), recipient);
+            }
+            BackupItem::MultiSignature(multisigned) => match handler.alert_confirmed(multisigned) {
+                Ok(notification) => self.send_notification_for_units(notification),
+                Err(error) => warn!(target: LOG_TARGET, "{}", error),
+            },
+            _ => {}
+        }
     }
 
-    fn handle_message_from_rmc(
-        &mut self,
-        message: RmcMessage<H::Hash, MK::Signature, MK::PartialMultisignature>,
-    ) {
-        self.rmc_message_to_network(message)
-    }
-
-    fn handle_multisigned(
-        &mut self,
-        handler: &mut Handler<H, D, MK>,
-        multisigned: Multisigned<H::Hash, MK>,
-    ) {
-        match handler.alert_confirmed(multisigned) {
-            Ok(notification) => self.send_notification_for_units(notification),
-            Err(error) => warn!(target: LOG_TARGET, "{}", error),
+    fn send_item_to_backup(&mut self, item: BackupItem<H, D, MK>) {
+        if self.items_for_backup.unbounded_send(item).is_err() {
+            warn!(
+                target: LOG_TARGET,
+                "{:?} Channel for passing items to backup was closed",
+                self.keychain.index()
+            );
+            self.exiting = true;
         }
     }
 
@@ -176,20 +188,27 @@ impl<H: Hasher, D: Data, MK: MultiKeychain> Service<H, D, MK> {
                     }
                 },
                 alert = self.alerts_from_units.next() => match alert {
-                    Some(alert) => self.handle_alert_from_runway(&mut handler, alert),
+                    Some(alert) => self.send_item_to_backup(BackupItem::OwnAlert(alert)),
                     None => {
                         error!(target: LOG_TARGET, "{:?} Alert stream closed.", self.keychain.index());
                         break;
                     }
                 },
                 message = self.messages_from_rmc.next() => match message {
-                    Some(message) => self.handle_message_from_rmc(message),
+                    Some(message) => self.rmc_message_to_network(message),
                     None => {
                         error!(target: LOG_TARGET, "{:?} RMC message stream closed.", self.keychain.index());
                         break;
                     }
                 },
-                multisigned = self.rmc.next_multisigned_hash().fuse() => self.handle_multisigned(&mut handler, multisigned),
+                multisigned = self.rmc.next_multisigned_hash().fuse() => self.send_item_to_backup(BackupItem::MultiSignature(multisigned)),
+                response = self.responses_from_backup.next() => match response {
+                    Some(item) => self.handle_response_from_backup(&mut handler, item),
+                    None => {
+                        error!(target: LOG_TARGET, "Receiver of responses from backup closed");
+                        break;
+                    }
+                },
                 _ = terminator.get_exit().fuse() => {
                     debug!(target: LOG_TARGET, "{:?} received exit signal", self.keychain.index());
                     self.exiting = true;

--- a/consensus/src/runway/mod.rs
+++ b/consensus/src/runway/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    alerts::{Alert, AlertConfig, ForkProof, ForkingNotification, NetworkMessage},
+    alerts::{Alert, ForkProof, ForkingNotification, NetworkMessage},
     consensus, handle_task_termination,
     member::UnitMessage,
     units::{
@@ -895,10 +895,7 @@ pub(crate) async fn run<H, D, US, UL, MK, DP, FH, SH>(
 
     let (alert_notifications_for_units, notifications_from_alerter) = mpsc::unbounded();
     let (alerts_for_alerter, alerts_from_units) = mpsc::unbounded();
-    let alert_config = AlertConfig {
-        session_id: config.session_id(),
-        n_members: config.n_members(),
-    };
+
     let alerter_terminator = terminator.add_offspring_connection("AlephBFT-alerter");
     let alerter_keychain = keychain.clone();
     let alert_messages_for_network = network_io.alert_messages_for_network;
@@ -910,11 +907,10 @@ pub(crate) async fn run<H, D, US, UL, MK, DP, FH, SH>(
         alert_messages_from_network,
         alert_notifications_for_units,
         alerts_from_units,
-        alert_config.n_members,
         backup_items_for_saver.clone(),
         backup_items_from_saver,
     );
-    let alerter_handler = crate::alerts::Handler::new(alerter_keychain, alert_config);
+    let alerter_handler = crate::alerts::Handler::new(alerter_keychain, config.session_id());
 
     let alerter_handle = spawn_handle.spawn_essential("runway/alerter", async move {
         alerter_service

--- a/consensus/src/testing/alerts.rs
+++ b/consensus/src/testing/alerts.rs
@@ -1,5 +1,5 @@
 use crate::{
-    alerts::{Alert, AlertConfig, AlertMessage, ForkProof, ForkingNotification, Handler, Service},
+    alerts::{Alert, AlertMessage, ForkProof, ForkingNotification, Handler, Service},
     units::{ControlHash, FullUnit, PreUnit},
     Index, Indexed, Keychain as _, NodeCount, NodeIndex, NodeMap, Recipient, Round, Signable,
     Signed, Terminator, UncheckedSigned,
@@ -214,7 +214,7 @@ impl TestCase {
         let (notifications_for_units, mut notifications_from_alerter) = mpsc::unbounded();
         let (alerts_for_alerter, alerts_from_units) = mpsc::unbounded();
         let (exit_alerter, exit) = oneshot::channel();
-        let n_members = keychain.node_count();
+        let _n_members = keychain.node_count();
         let (dummy_backup_tx, dummy_backup_rx) = mpsc::unbounded();
 
         let mut alerter_service = Service::new(
@@ -223,17 +223,10 @@ impl TestCase {
             messages_from_network,
             notifications_for_units,
             alerts_from_units,
-            n_members,
             dummy_backup_tx,
             dummy_backup_rx, // todo: include the actual backup service in the test
         );
-        let alerter_handler = Handler::new(
-            keychain,
-            AlertConfig {
-                n_members,
-                session_id: 0,
-            },
-        );
+        let alerter_handler = Handler::new(keychain, 0);
 
         tokio::spawn(async move {
             alerter_service

--- a/consensus/src/testing/alerts.rs
+++ b/consensus/src/testing/alerts.rs
@@ -215,6 +215,7 @@ impl TestCase {
         let (alerts_for_alerter, alerts_from_units) = mpsc::unbounded();
         let (exit_alerter, exit) = oneshot::channel();
         let n_members = keychain.node_count();
+        let (dummy_backup_tx, dummy_backup_rx) = mpsc::unbounded();
 
         let mut alerter_service = Service::new(
             keychain,
@@ -223,6 +224,8 @@ impl TestCase {
             notifications_for_units,
             alerts_from_units,
             n_members,
+            dummy_backup_tx,
+            dummy_backup_rx, // todo: include the actual backup service in the test
         );
         let alerter_handler = Handler::new(
             keychain,

--- a/rmc/src/lib.rs
+++ b/rmc/src/lib.rs
@@ -199,8 +199,6 @@ impl<H: Signable + Hash + Eq + Clone + Debug, MK: MultiKeychain> ReliableMultica
         network_rx: UnboundedReceiver<Message<H, MK::Signature, MK::PartialMultisignature>>,
         network_tx: UnboundedSender<Message<H, MK::Signature, MK::PartialMultisignature>>,
         keychain: MK,
-        //kept for compatibility
-        _node_count: NodeCount,
         scheduler: impl TaskScheduler<Task<H, MK>> + 'static,
     ) -> Self {
         let (multisigned_hashes_tx, multisigned_hashes_rx) = unbounded();
@@ -413,7 +411,6 @@ mod tests {
                     rx,
                     tx,
                     keychains[i],
-                    node_count,
                     DoublingDelayScheduler::new(Duration::from_millis(1)),
                 );
                 rmcs.push(rmc);


### PR DESCRIPTION
Implement backup saving mechanism for the alerter `Service`.
* introduce appropriate channels in `Service` for communication with `backup`.
* send own and network alerts, and multisigs to backup when they appear in the `Service::run` main select loop
* perform handling of the above items and sending messages to network only after getting a confirmation from `backup` that the item has been saved
* because of the design, the items which `Service` sends to `backup` are guaranteed to preserve their order in storage, and `Service` will receive confirmations from `backup` in the same order.

Currently we don't test any backup related behavior of alerter `Service`.