### PR TITLE
return the creator of a unit with the unit data when the unit is finalized

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-bft"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "aleph-bft-mock",
  "aleph-bft-rmc",
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-bft-mock"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "aleph-bft-types",
  "async-trait",
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-bft-types"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "aleph-bft-crypto",
  "async-trait",

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ More details are available [in the book][reference-link-implementation-details].
 - Import AlephBFT in your crate
   ```toml
   [dependencies]
-  aleph-bft = "^0.29"
+  aleph-bft = "^0.30"
   ```
 - The main entry point is the `run_session` function, which returns a Future that runs the
   consensus algorithm.

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-bft"
-version = "0.29.0"
+version = "0.30.0"
 edition = "2021"
 authors = ["Cardinal Cryptography"]
 categories = ["algorithms", "data-structures", "cryptography", "database"]
@@ -14,7 +14,7 @@ description = "AlephBFT is an asynchronous and Byzantine fault tolerant consensu
 
 [dependencies]
 aleph-bft-rmc = { path = "../rmc", version = "0.10" }
-aleph-bft-types = { path = "../types", version = "0.9" }
+aleph-bft-types = { path = "../types", version = "0.10" }
 anyhow = "1.0"
 async-trait = "0.1"
 codec = { package = "parity-scale-codec", version = "3.0", default-features = false, features = ["derive"] }

--- a/consensus/src/runway/mod.rs
+++ b/consensus/src/runway/mod.rs
@@ -657,18 +657,21 @@ where
     fn on_ordered_batch(&mut self, batch: Vec<H::Hash>) {
         let data_iter: Vec<_> = batch
             .iter()
-            .filter_map(|h| {
-                self.store
+            .map(|h| {
+                let unit = self
+                    .store
                     .unit_by_hash(h)
                     .expect("Ordered units must be in store")
-                    .as_signable()
-                    .data()
-                    .clone()
+                    .as_signable();
+
+                (unit.data().clone(), unit.creator())
             })
             .collect();
 
-        for d in data_iter {
-            self.finalization_handler.data_finalized(d);
+        for (d, creator) in data_iter {
+            if let Some(d) = d {
+                self.finalization_handler.data_finalized(d, creator);
+            }
         }
     }
 

--- a/docs/src/aleph_bft_api.md
+++ b/docs/src/aleph_bft_api.md
@@ -18,7 +18,7 @@ The FinalizationHandler trait is an abstraction for a component that should hand
 
 ```rust
 pub trait FinalizationHandler<Data> {
-    fn data_finalized(&mut self, data: Data);
+    fn data_finalized(&mut self, data: Data, creator: NodeIndex);
 }
 ```
 

--- a/examples/ordering/src/dataio.rs
+++ b/examples/ordering/src/dataio.rs
@@ -56,7 +56,7 @@ pub struct FinalizationHandler {
 }
 
 impl FinalizationHandlerT<Data> for FinalizationHandler {
-    fn data_finalized(&mut self, d: Data) {
+    fn data_finalized(&mut self, d: Data, _creator: NodeIndex) {
         if let Err(e) = self.tx.unbounded_send(d) {
             error!(target: "finalization-handler", "Error when sending data from FinalizationHandler {:?}.", e);
         }

--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-bft-mock"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 authors = ["Cardinal Cryptography"]
 documentation = "https://docs.rs/?"
@@ -11,7 +11,7 @@ readme = "./README.md"
 description = "Mock implementations of traits required by the aleph-bft package. Do NOT use outside of testing!"
 
 [dependencies]
-aleph-bft-types = { path = "../types", version = "0.9" }
+aleph-bft-types = { path = "../types", version = "0.10" }
 async-trait = "0.1"
 codec = { package = "parity-scale-codec", version = "3.0", default-features = false, features = ["derive"] }
 futures = "0.3"

--- a/mock/src/dataio.rs
+++ b/mock/src/dataio.rs
@@ -1,4 +1,6 @@
-use aleph_bft_types::{DataProvider as DataProviderT, FinalizationHandler as FinalizationHandlerT};
+use aleph_bft_types::{
+    DataProvider as DataProviderT, FinalizationHandler as FinalizationHandlerT, NodeIndex,
+};
 use async_trait::async_trait;
 use codec::{Decode, Encode};
 use futures::{channel::mpsc::unbounded, future::pending};
@@ -71,7 +73,7 @@ pub struct FinalizationHandler {
 }
 
 impl FinalizationHandlerT<Data> for FinalizationHandler {
-    fn data_finalized(&mut self, d: Data) {
+    fn data_finalized(&mut self, d: Data, _creator: NodeIndex) {
         if let Err(e) = self.tx.unbounded_send(d) {
             error!(target: "finalization-handler", "Error when sending data from FinalizationHandler {:?}.", e);
         }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-bft-types"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 authors = ["Cardinal Cryptography"]
 documentation = "https://docs.rs/?"

--- a/types/src/dataio.rs
+++ b/types/src/dataio.rs
@@ -1,5 +1,7 @@
 use async_trait::async_trait;
 
+use crate::NodeIndex;
+
 /// The source of data items that consensus should order.
 ///
 /// AlephBFT internally calls [`DataProvider::get_data`] whenever a new unit is created and data needs to be placed inside.
@@ -19,5 +21,5 @@ pub trait DataProvider<Data>: Sync + Send + 'static {
 pub trait FinalizationHandler<Data>: Sync + Send + 'static {
     /// Data, provided by [DataProvider::get_data], has been finalized.
     /// The calls to this function follow the order of finalization.
-    fn data_finalized(&mut self, data: Data);
+    fn data_finalized(&mut self, data: Data, creator: NodeIndex);
 }


### PR DESCRIPTION
This pr is supposed to simplify the integration of Aleph Bft into Fedimint, a byzantine fault tolerant decentralised  chaumian ecash mint we call a Federation. Fedimint uses Aleph to order incoming transactions submitted by the clients. The inputs and outputs of the transaction are either chaumian ecash notes, on-chain bitcoin or smart contracts that enable integration with the bitcoin lightning network enabling instant settlement. After a transaction has been ordered by Aleph the system has to achieve consensus wether a transaction is valid by validating all inputs and outputs individually. 

An on-chain bitcoin input is the output of a bitcoin transaction that sends money to the Federation and is at least six blocks deep in the blockchain. Therefore we need to achieve consensus on the current block height of the bitcoin blockchain to validate the on-chain bitcoin input.

An on-chain bitcoin output is a bitcoin transaction that the federation threshold signs that sends money from the Federation to the clients requested bitcoin address. To assure that the  bitcoin transaction will be included into the bitcoin blockchain the Federation has to add a high enough fee to the transaction which is also paid by the user. Therefore, to validate an on-chain output of a Fedimint transaction the Federation has to achieve consensus on the current ferrate necessary.

Finally, Lightning outputs of a Fedimint transaction are so called Hash Timelocked Contracts or HTLCs. To check wether a time lock has passed the system has to achieve consensus on the current time.

To achieve consensus on an integer like block height or ferrate to submit additional types of consensus items to the broadcast alongside the transactions from the clients. In our examples a node would submit its local ferrate and block height to the broadcast which we call votes. We remember the last such vote for every node and then recalculate the median to achieve consensus every time a vote is updated. Therefore we need to know which node submitted a vote. The naive solution would be to sign every vote we want to submit with the keychain before submitting it to aleph bft. While this is not an issue with strictly increasing values such as block height in case of the ferrate however there could be attacks by resubmitting an old vote by a different node; this is generally known as replay attacks. Hence we would have to sign an increasing integer for every submitted vote and save the integer corresponding to the last vote to prevent such attacks. This introduces unnecessary complexity as the extra information that needs to be returned is trivially available.

Furthermore, Fedimint is built as an extensible system that can be extended with additional functionality by third parties in the form of new input and output types as well as new consensus items that are needed to validate these inputs and outputs. One extension currently in development is called stability pools which allows clients to enter smart contracts with financial service providers to hedge against falling dollar prices of bitcoin. To enforce those contracts the federation needs to achieve consensus on the current dollar value of bitcoin.