### PR TITLE
A0-3186: Simplify DoublingDelayScheduler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-bft-rmc"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "aleph-bft-crypto",
  "aleph-bft-mock",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-bft-rmc"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "aleph-bft-crypto",
  "aleph-bft-mock",

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 description = "AlephBFT is an asynchronous and Byzantine fault tolerant consensus protocol aimed at ordering arbitrary messages (transactions). It has been designed to continuously operate even in the harshest conditions: with no bounds on message-delivery delays and in the presence of malicious actors. This makes it an excellent fit for blockchain-related applications."
 
 [dependencies]
-aleph-bft-rmc = { path = "../rmc", version = "0.9" }
+aleph-bft-rmc = { path = "../rmc", version = "0.10" }
 aleph-bft-types = { path = "../types", version = "0.8" }
 anyhow = "1.0"
 async-trait = "0.1"

--- a/rmc/Cargo.toml
+++ b/rmc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-bft-rmc"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 authors = ["Cardinal Cryptography"]
 categories = ["algorithms", "cryptography"]

--- a/rmc/Cargo.toml
+++ b/rmc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-bft-rmc"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 authors = ["Cardinal Cryptography"]
 categories = ["algorithms", "cryptography"]

--- a/rmc/Cargo.toml
+++ b/rmc/Cargo.toml
@@ -23,4 +23,4 @@ log = "0.4"
 [dev-dependencies]
 aleph-bft-mock = { path = "../mock" }
 rand = "0.8"
-tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "time"] }

--- a/rmc/src/lib.rs
+++ b/rmc/src/lib.rs
@@ -107,7 +107,6 @@ impl<T> DoublingDelayScheduler<T> {
         DoublingDelayScheduler::with_tasks(vec![], initial_delay)
     }
 
-    /// Choose `delta >> 0` to prevent the tasks from bunching.
     pub fn with_tasks(initial_tasks: Vec<T>, initial_delay: Duration) -> Self {
         let mut scheduler = DoublingDelayScheduler {
             initial_delay,

--- a/rmc/src/lib.rs
+++ b/rmc/src/lib.rs
@@ -586,7 +586,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn scheduler_properly_handler_initial_bunch_of_tasks() {
+    async fn scheduler_properly_handles_initial_bunch_of_tasks() {
         let tasks = (0..5).collect();
         let before = Instant::now();
         let mut scheduler = DoublingDelayScheduler::new_with_tasks(

--- a/rmc/src/lib.rs
+++ b/rmc/src/lib.rs
@@ -614,9 +614,10 @@ mod tests {
 
     #[tokio::test]
     async fn asking_empty_scheduler_for_next_task_blocks() {
-        let mut scheduler: DoublingDelayScheduler<u32> = DoublingDelayScheduler::new(Duration::from_millis(25));
+        let mut scheduler: DoublingDelayScheduler<u32> =
+            DoublingDelayScheduler::new(Duration::from_millis(25));
         let future = tokio::time::timeout(Duration::from_millis(30), scheduler.next_task());
         let result = future.await;
-        assert!(matches!(result, Err(_))); // elapsed
+        assert!(result.is_err()); // elapsed
     }
 }


### PR DESCRIPTION
Refactor `DoublingDelayScheduler` - channel communication between `add_task` and `next_task` was not needed.
`add_task` and `next_task` take `&mut self` so it's impossible to add a task while awaiting some other task's delay in `next_task`. This way it is guaranteed that when a task is added by `add_task`, the next call to `next_task` considers this task before other tasks with long delays.

Added a small unit test