### PR TITLE
A0-3240: Move Terminator to types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,7 @@ version = "0.0.3"
 dependencies = [
  "aleph-bft",
  "aleph-bft-mock",
+ "aleph-bft-types",
  "async-trait",
  "clap 4.4.4",
  "env_logger",
@@ -118,6 +119,7 @@ dependencies = [
  "afl",
  "aleph-bft",
  "aleph-bft-mock",
+ "aleph-bft-types",
  "async-trait",
  "env_logger",
  "futures",
@@ -166,7 +168,9 @@ dependencies = [
  "aleph-bft-crypto",
  "async-trait",
  "futures",
+ "log",
  "parity-scale-codec",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-bft"
-version = "0.28.2"
+version = "0.29.0"
 dependencies = [
  "aleph-bft-mock",
  "aleph-bft-rmc",
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-bft-types"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "aleph-bft-crypto",
  "async-trait",

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ More details are available [in the book][reference-link-implementation-details].
 - Import AlephBFT in your crate
   ```toml
   [dependencies]
-  aleph-bft = "^0.28"
+  aleph-bft = "^0.29"
   ```
 - The main entry point is the `run_session` function, which returns a Future that runs the
   consensus algorithm.

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-bft"
-version = "0.28.2"
+version = "0.29.0"
 edition = "2021"
 authors = ["Cardinal Cryptography"]
 categories = ["algorithms", "data-structures", "cryptography", "database"]

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -14,7 +14,7 @@ description = "AlephBFT is an asynchronous and Byzantine fault tolerant consensu
 
 [dependencies]
 aleph-bft-rmc = { path = "../rmc", version = "0.10" }
-aleph-bft-types = { path = "../types", version = "0.8" }
+aleph-bft-types = { path = "../types", version = "0.9" }
 anyhow = "1.0"
 async-trait = "0.1"
 codec = { package = "parity-scale-codec", version = "3.0", default-features = false, features = ["derive"] }

--- a/consensus/src/alerts/service.rs
+++ b/consensus/src/alerts/service.rs
@@ -3,9 +3,10 @@ use crate::{
         handler::{Handler, OnNetworkAlertResponse, OnOwnAlertResponse, RmcResponse},
         Alert, AlertData, AlertMessage, ForkingNotification, NetworkMessage,
     },
-    Data, Hasher, MultiKeychain, Multisigned, NodeIndex, Receiver, Recipient, Sender, Terminator,
+    Data, Hasher, MultiKeychain, Multisigned, NodeIndex, Receiver, Recipient, Sender,
 };
 use aleph_bft_rmc::{DoublingDelayScheduler, Message as RmcMessage, ReliableMulticast};
+use aleph_bft_types::Terminator;
 use futures::{channel::mpsc, FutureExt, StreamExt};
 use log::{debug, error, warn};
 use std::{collections::HashMap, time};

--- a/consensus/src/backup/saver.rs
+++ b/consensus/src/backup/saver.rs
@@ -1,12 +1,13 @@
 use std::io::Write;
 
+use aleph_bft_types::Terminator;
 use codec::Encode;
 use futures::{FutureExt, StreamExt};
 use log::{debug, error};
 
 use crate::{
     alerts::AlertData, backup::BackupItem, units::UncheckedSignedUnit, Data, Hasher, MultiKeychain,
-    Receiver, Sender, Terminator,
+    Receiver, Sender,
 };
 
 const LOG_TARGET: &str = "AlephBFT-backup-saver";
@@ -108,12 +109,13 @@ mod tests {
     };
 
     use aleph_bft_mock::{Data, Hasher64, Keychain, Saver, Signature};
+    use aleph_bft_types::Terminator;
 
     use crate::{
         alerts::{Alert, AlertData},
         backup::BackupSaver,
         units::{creator_set, preunit_to_unchecked_signed_unit, UncheckedSignedUnit},
-        NodeCount, NodeIndex, Terminator,
+        NodeCount, NodeIndex,
     };
 
     type TestBackupSaver = BackupSaver<Hasher64, Data, Keychain, Saver>;

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -1,3 +1,4 @@
+use aleph_bft_types::{handle_task_termination, Terminator};
 use futures::{
     channel::{mpsc, oneshot},
     future::pending,
@@ -9,10 +10,9 @@ use crate::{
     config::Config,
     creation,
     extender::Extender,
-    handle_task_termination,
     runway::{NotificationIn, NotificationOut},
     terminal::Terminal,
-    Hasher, Receiver, Round, Sender, SpawnHandle, Terminator,
+    Hasher, Receiver, Round, Sender, SpawnHandle,
 };
 
 pub(crate) async fn run<H: Hasher + 'static>(

--- a/consensus/src/creation/mod.rs
+++ b/consensus/src/creation/mod.rs
@@ -2,8 +2,9 @@ use crate::{
     config::{Config as GeneralConfig, DelaySchedule},
     runway::NotificationOut,
     units::{PreUnit, Unit},
-    Hasher, NodeCount, NodeIndex, Receiver, Round, Sender, Terminator,
+    Hasher, NodeCount, NodeIndex, Receiver, Round, Sender,
 };
+use aleph_bft_types::Terminator;
 use futures::{
     channel::{
         mpsc::{SendError, TrySendError},

--- a/consensus/src/extender.rs
+++ b/consensus/src/extender.rs
@@ -1,9 +1,10 @@
 use futures::{FutureExt, StreamExt};
 use std::collections::{HashMap, VecDeque};
 
+use aleph_bft_types::Terminator;
 use log::{debug, warn};
 
-use crate::{Hasher, NodeCount, NodeIndex, NodeMap, Receiver, Round, Sender, Terminator};
+use crate::{Hasher, NodeCount, NodeIndex, NodeMap, Receiver, Round, Sender};
 
 pub(crate) struct ExtenderUnit<H: Hasher> {
     creator: NodeIndex,

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -11,7 +11,6 @@ mod member;
 mod network;
 mod runway;
 mod terminal;
-mod terminator;
 mod units;
 
 mod backup;
@@ -30,7 +29,6 @@ pub use config::{
 };
 pub use member::{run_session, LocalIO};
 pub use network::NetworkData;
-pub use terminator::{handle_task_termination, Terminator};
 
 type Receiver<T> = futures::channel::mpsc::UnboundedReceiver<T>;
 type Sender<T> = futures::channel::mpsc::UnboundedSender<T>;

--- a/consensus/src/member.rs
+++ b/consensus/src/member.rs
@@ -1,5 +1,4 @@
 use crate::{
-    handle_task_termination,
     member::Task::{CoordRequest, ParentsRequest, RequestNewest, UnitBroadcast},
     network,
     runway::{
@@ -9,9 +8,9 @@ use crate::{
     task_queue::TaskQueue,
     units::{UncheckedSignedUnit, UnitCoord},
     Config, Data, DataProvider, FinalizationHandler, Hasher, MultiKeychain, Network, NodeIndex,
-    Receiver, Recipient, Round, Sender, Signature, SpawnHandle, Terminator, UncheckedSigned,
+    Receiver, Recipient, Round, Sender, Signature, SpawnHandle, UncheckedSigned,
 };
-use aleph_bft_types::NodeMap;
+use aleph_bft_types::{handle_task_termination, NodeMap, Terminator};
 use codec::{Decode, Encode};
 use futures::{channel::mpsc, pin_mut, FutureExt, StreamExt};
 use futures_timer::Delay;

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -1,7 +1,8 @@
 use crate::{
     alerts::AlertMessage, member::UnitMessage, Data, Hasher, Network, PartialMultisignature,
-    Receiver, Recipient, Sender, Signature, Terminator,
+    Receiver, Recipient, Sender, Signature,
 };
+use aleph_bft_types::Terminator;
 use codec::{Decode, Encode};
 use futures::{FutureExt, StreamExt};
 use log::{debug, error, warn};

--- a/consensus/src/runway/mod.rs
+++ b/consensus/src/runway/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     alerts::{Alert, ForkProof, ForkingNotification, NetworkMessage},
-    consensus, handle_task_termination,
+    consensus,
     member::UnitMessage,
     units::{
         ControlHash, PreUnit, SignedUnit, UncheckedSignedUnit, Unit, UnitCoord, UnitStore,
@@ -8,9 +8,9 @@ use crate::{
     },
     Config, Data, DataProvider, FinalizationHandler, Hasher, Index, Keychain, MultiKeychain,
     NodeCount, NodeIndex, NodeMap, Receiver, Round, Sender, Signature, Signed, SpawnHandle,
-    Terminator, UncheckedSigned,
+    UncheckedSigned,
 };
-use aleph_bft_types::Recipient;
+use aleph_bft_types::{handle_task_termination, Recipient, Terminator};
 use futures::{
     channel::{mpsc, oneshot},
     pin_mut, Future, FutureExt, StreamExt,

--- a/consensus/src/runway/packer.rs
+++ b/consensus/src/runway/packer.rs
@@ -1,8 +1,8 @@
 use crate::{
     units::{FullUnit, PreUnit, SignedUnit},
     Data, DataProvider, Hasher, MultiKeychain, NodeIndex, Receiver, Sender, SessionId, Signed,
-    Terminator,
 };
+use aleph_bft_types::Terminator;
 use futures::{pin_mut, FutureExt, StreamExt};
 use log::{debug, error};
 use std::marker::PhantomData;
@@ -100,10 +100,10 @@ mod tests {
     use super::Packer;
     use crate::{
         units::{ControlHash, PreUnit, SignedUnit},
-        NodeCount, NodeIndex, Receiver, Sender, SessionId, Terminator,
+        NodeCount, NodeIndex, Receiver, Sender, SessionId,
     };
     use aleph_bft_mock::{Data, DataProvider, Hasher64, Keychain, StalledDataProvider};
-    use aleph_bft_types::NodeMap;
+    use aleph_bft_types::{NodeMap, Terminator};
     use futures::{
         channel::{mpsc, oneshot},
         pin_mut, FutureExt, StreamExt,

--- a/consensus/src/terminal.rs
+++ b/consensus/src/terminal.rs
@@ -8,8 +8,9 @@ use crate::{
     extender::ExtenderUnit,
     runway::{NotificationIn, NotificationOut},
     units::{ControlHash, Unit, UnitCoord},
-    Hasher, NodeCount, NodeIndex, NodeMap, Receiver, Round, Sender, Terminator,
+    Hasher, NodeCount, NodeIndex, NodeMap, Receiver, Round, Sender,
 };
+use aleph_bft_types::Terminator;
 use codec::{Decode, Encode};
 use log::{debug, trace, warn};
 

--- a/consensus/src/testing/alerts.rs
+++ b/consensus/src/testing/alerts.rs
@@ -2,10 +2,11 @@ use crate::{
     alerts::{Alert, AlertMessage, ForkProof, ForkingNotification, Handler, Service},
     units::{ControlHash, FullUnit, PreUnit},
     Index, Indexed, Keychain as _, NodeCount, NodeIndex, NodeMap, Recipient, Round, Signable,
-    Signed, Terminator, UncheckedSigned,
+    Signed, UncheckedSigned,
 };
 use aleph_bft_mock::{Data, Hasher64, Keychain, PartialMultisignature, Signature};
 use aleph_bft_rmc::Message as RmcMessage;
+use aleph_bft_types::Terminator;
 use futures::{
     channel::{mpsc, oneshot},
     FutureExt, StreamExt,

--- a/consensus/src/testing/consensus.rs
+++ b/consensus/src/testing/consensus.rs
@@ -3,9 +3,10 @@ use crate::{
     runway::{NotificationIn, NotificationOut},
     testing::{complete_oneshot, gen_config, gen_delay_config, init_log},
     units::{ControlHash, PreUnit, Unit, UnitCoord},
-    Hasher, NodeIndex, SpawnHandle, Terminator,
+    Hasher, NodeIndex, SpawnHandle,
 };
 use aleph_bft_mock::{Hasher64, Spawner};
+use aleph_bft_types::Terminator;
 use codec::Encode;
 use futures::{
     channel::{

--- a/consensus/src/testing/creation.rs
+++ b/consensus/src/testing/creation.rs
@@ -3,9 +3,10 @@ use crate::{
     runway::NotificationOut as GenericNotificationOut,
     testing::{gen_config, gen_delay_config},
     units::{FullUnit as GenericFullUnit, PreUnit as GenericPreUnit, Unit as GenericUnit},
-    NodeCount, Receiver, Round, Sender, Terminator,
+    NodeCount, Receiver, Round, Sender,
 };
 use aleph_bft_mock::{Data, Hasher64};
+use aleph_bft_types::Terminator;
 use futures::{
     channel::{mpsc, oneshot},
     FutureExt, StreamExt,

--- a/consensus/src/testing/dag.rs
+++ b/consensus/src/testing/dag.rs
@@ -3,9 +3,10 @@ use crate::{
     runway::{NotificationIn, NotificationOut},
     testing::{complete_oneshot, gen_config, gen_delay_config},
     units::{ControlHash, PreUnit, Unit},
-    NodeCount, NodeIndex, NodeMap, NodeSubset, Receiver, Round, Sender, SpawnHandle, Terminator,
+    NodeCount, NodeIndex, NodeMap, NodeSubset, Receiver, Round, Sender, SpawnHandle,
 };
 use aleph_bft_mock::{Hash64, Hasher64, Spawner};
+use aleph_bft_types::Terminator;
 use futures::{
     channel::{mpsc, oneshot},
     stream::StreamExt,

--- a/consensus/src/testing/mod.rs
+++ b/consensus/src/testing/mod.rs
@@ -10,12 +10,13 @@ mod unreliable;
 
 use crate::{
     create_config, run_session, Config, DelayConfig, LocalIO, Network as NetworkT, NodeCount,
-    NodeIndex, SpawnHandle, TaskHandle, Terminator,
+    NodeIndex, SpawnHandle, TaskHandle,
 };
 use aleph_bft_mock::{
     Data, DataProvider, FinalizationHandler, Hasher64, Keychain, Loader, Network as MockNetwork,
     PartialMultisignature, ReconnectSender as ReconnectSenderGeneric, Saver, Signature, Spawner,
 };
+use aleph_bft_types::Terminator;
 use futures::channel::{mpsc::UnboundedReceiver, oneshot};
 use parking_lot::Mutex;
 use std::{sync::Arc, time::Duration};

--- a/examples/blockchain/Cargo.toml
+++ b/examples/blockchain/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 [dependencies]
 aleph-bft = { path = "../../consensus", version = "*" }
 aleph-bft-mock = { path = "../../mock", version = "*" }
+aleph-bft-types = { path = "../../types", version = "*" }
 async-trait = "0.1"
 clap = { version = "4", features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "3.0", default-features = false, features = ["derive"] }

--- a/examples/blockchain/src/chain.rs
+++ b/examples/blockchain/src/chain.rs
@@ -1,5 +1,6 @@
 use crate::{network::NetworkData, DataStore};
-use aleph_bft::{NodeIndex, Terminator};
+use aleph_bft::NodeIndex;
+use aleph_bft_types::Terminator;
 use codec::{Decode, Encode};
 use futures::{
     channel::mpsc::{UnboundedReceiver, UnboundedSender},

--- a/examples/blockchain/src/main.rs
+++ b/examples/blockchain/src/main.rs
@@ -10,8 +10,9 @@ use futures::{channel::oneshot, StreamExt};
 use log::{debug, error, info};
 use time::{macros::format_description, OffsetDateTime};
 
-use aleph_bft::{run_session, NodeIndex, Terminator};
+use aleph_bft::{run_session, NodeIndex};
 use aleph_bft_mock::{FinalizationHandler, Keychain, Loader, Saver, Spawner};
+use aleph_bft_types::Terminator;
 use chain::{run_blockchain, Block, BlockNum, ChainConfig};
 use data::{Data, DataProvider, DataStore};
 use network::{Address, NetworkData, NetworkManager};

--- a/examples/blockchain/src/network.rs
+++ b/examples/blockchain/src/network.rs
@@ -1,6 +1,7 @@
 use crate::{Block, Data};
-use aleph_bft::{NodeIndex, Recipient, Terminator};
+use aleph_bft::{NodeIndex, Recipient};
 use aleph_bft_mock::{Hasher64, PartialMultisignature, Signature};
+use aleph_bft_types::Terminator;
 use codec::{Decode, Encode};
 use futures::{
     channel::mpsc::{self, UnboundedReceiver, UnboundedSender},

--- a/examples/ordering/src/main.rs
+++ b/examples/ordering/src/main.rs
@@ -1,8 +1,9 @@
 mod dataio;
 mod network;
 
-use aleph_bft::{run_session, NodeIndex, Terminator};
+use aleph_bft::{run_session, NodeIndex};
 use aleph_bft_mock::{Keychain, Spawner};
+use aleph_bft_types::Terminator;
 use clap::Parser;
 use dataio::{Data, DataProvider, FinalizationHandler};
 use futures::{channel::oneshot, StreamExt};

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,6 +11,7 @@ cargo-fuzz = true
 [dependencies]
 aleph-bft = { path = "../consensus", version = "*" }
 aleph-bft-mock = { path = "../mock", version = "*" }
+aleph-bft-types = { path = "../types", version = "*" }
 async-trait = "0.1"
 codec = { package = "parity-scale-codec", version = "3.0", default-features = false, features = ["derive", "std"] }
 env_logger = "0.10"

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -1,11 +1,12 @@
 use aleph_bft::{
     create_config, run_session, Config, DelayConfig, LocalIO, Network as NetworkT, NetworkData,
-    NodeCount, NodeIndex, Recipient, SpawnHandle, TaskHandle, Terminator,
+    NodeCount, NodeIndex, Recipient, SpawnHandle, TaskHandle,
 };
 use aleph_bft_mock::{
     Data, DataProvider, FinalizationHandler, Hasher64, Keychain, Loader, NetworkHook,
     PartialMultisignature, Router, Saver, Signature,
 };
+use aleph_bft_types::Terminator;
 use codec::{Decode, Encode, IoReader};
 use futures::{
     channel::{oneshot, oneshot::Receiver},

--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -11,7 +11,7 @@ readme = "./README.md"
 description = "Mock implementations of traits required by the aleph-bft package. Do NOT use outside of testing!"
 
 [dependencies]
-aleph-bft-types = { path = "../types", version = "0.8" }
+aleph-bft-types = { path = "../types", version = "0.9" }
 async-trait = "0.1"
 codec = { package = "parity-scale-codec", version = "3.0", default-features = false, features = ["derive"] }
 futures = "0.3"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -15,3 +15,7 @@ aleph-bft-crypto = { path = "../crypto", version = "0.7" }
 async-trait = "0.1"
 codec = { package = "parity-scale-codec", version = "3.0", default-features = false, features = ["derive"] }
 futures = "0.3"
+log = "0.4"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "time"] }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-bft-types"
-version = "0.8.1"
+version = "0.9.0"
 edition = "2021"
 authors = ["Cardinal Cryptography"]
 documentation = "https://docs.rs/?"

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -3,6 +3,7 @@
 mod dataio;
 mod network;
 mod tasks;
+mod terminator;
 
 pub use aleph_bft_crypto::{
     IncompleteMultisignatureError, Index, Indexed, Keychain, MultiKeychain, Multisigned, NodeCount,
@@ -12,6 +13,7 @@ pub use aleph_bft_crypto::{
 pub use dataio::{DataProvider, FinalizationHandler};
 pub use network::{Network, Recipient};
 pub use tasks::{SpawnHandle, TaskHandle};
+pub use terminator::{handle_task_termination, Terminator};
 
 use codec::Codec;
 use std::{fmt::Debug, hash::Hash as StdHash};

--- a/types/src/terminator.rs
+++ b/types/src/terminator.rs
@@ -1,3 +1,4 @@
+use aleph_bft_crypto::NodeIndex;
 use futures::{
     channel::oneshot::{channel, Receiver, Sender},
     future::FusedFuture,
@@ -170,7 +171,7 @@ pub async fn handle_task_termination<T>(
     task_handle: T,
     target: &'static str,
     name: &'static str,
-    index: aleph_bft_types::NodeIndex,
+    index: NodeIndex,
 ) where
     T: FusedFuture<Output = Result<(), ()>>,
 {


### PR DESCRIPTION
Move `Terminator` to `types` as it will be used also in `rmc`. So far `Terminator` resided in `consensus` making it impossible to be used by other components.