### PR TITLE
A0-544: backup inject

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-bft"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "aleph-bft-mock",
  "aleph-bft-rmc",
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-bft-rmc"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "aleph-bft-crypto",
  "aleph-bft-mock",

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ More details are available [in the book][reference-link-implementation-details].
 - Import AlephBFT in your crate
   ```toml
   [dependencies]
-  aleph-bft = "^0.31"
+  aleph-bft = "^0.32"
   ```
 - The main entry point is the `run_session` function, which returns a Future that runs the
   consensus algorithm.

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-bft"
-version = "0.31.0"
+version = "0.32.0"
 edition = "2021"
 authors = ["Cardinal Cryptography"]
 categories = ["algorithms", "data-structures", "cryptography", "database"]

--- a/consensus/src/alerts/handler.rs
+++ b/consensus/src/alerts/handler.rs
@@ -1,5 +1,6 @@
 use crate::{
     alerts::{Alert, ForkProof, ForkingNotification},
+    units::UncheckedSignedUnit,
     Data, Hasher, Keychain, MultiKeychain, Multisigned, NodeIndex, PartialMultisignature,
     Recipient, SessionId, Signature, Signed, UncheckedSigned,
 };
@@ -10,7 +11,6 @@ use std::{
     collections::{HashMap, HashSet},
     fmt::{Display, Formatter},
 };
-use crate::units::UncheckedSignedUnit;
 
 #[derive(Debug, PartialEq)]
 pub enum Error {
@@ -323,11 +323,8 @@ mod tests {
         let fork_proof = make_fork_proof(forker_index, &forker_keychain, 0, n_members);
         let alert = Alert::new(own_index, fork_proof, vec![]);
         let signed_alert = Signed::sign(alert.clone(), &this.keychain).into_unchecked();
-        let alert_hash = Signable::hash(&alert);
-        assert_eq!(
-            this.on_own_alert(alert),
-            signed_alert,
-        );
+        let _alert_hash = Signable::hash(&alert);
+        assert_eq!(this.on_own_alert(alert), signed_alert,);
     }
 
     #[test]

--- a/consensus/src/alerts/handler.rs
+++ b/consensus/src/alerts/handler.rs
@@ -1,5 +1,5 @@
 use crate::{
-    alerts::{Alert, AlertMessage, ForkProof, ForkingNotification},
+    alerts::{Alert, ForkProof, ForkingNotification},
     Data, Hasher, Keychain, MultiKeychain, Multisigned, NodeIndex, PartialMultisignature,
     Recipient, SessionId, Signature, Signed, UncheckedSigned,
 };
@@ -270,7 +270,7 @@ mod tests {
     use crate::{
         alerts::{
             handler::{Error, Handler, RmcResponse},
-            Alert, AlertMessage, ForkProof, ForkingNotification,
+            Alert, ForkProof, ForkingNotification,
         },
         units::{ControlHash, FullUnit, PreUnit},
         PartiallyMultisigned, Recipient, Round,

--- a/consensus/src/alerts/mod.rs
+++ b/consensus/src/alerts/mod.rs
@@ -60,7 +60,7 @@ impl<H: Hasher, D: Data, S: Signature> Alert<H, D, S> {
         }
     }
 
-    fn hash(&self) -> H::Hash {
+    pub fn hash(&self) -> H::Hash {
         let hash = *self.hash.read();
         match hash {
             Some(hash) => hash,
@@ -74,7 +74,7 @@ impl<H: Hasher, D: Data, S: Signature> Alert<H, D, S> {
 
     // Simplified forker check, should only be called for alerts that have already been checked to
     // contain valid proofs.
-    fn forker(&self) -> NodeIndex {
+    pub fn forker(&self) -> NodeIndex {
         self.proof.0.as_signable().creator()
     }
 
@@ -131,7 +131,7 @@ pub enum ForkingNotification<H: Hasher, D: Data, S: Signature> {
 
 #[derive(Clone, Debug, Decode, Encode, PartialEq)]
 pub enum AlertData<H: Hasher, D: Data, MK: MultiKeychain> {
-    OwnAlert(Alert<H, D, MK::Signature>),
-    NetworkAlert(Alert<H, D, MK::Signature>),
+    OwnAlert(UncheckedSigned<Alert<H, D, MK::Signature>, MK::Signature>),
+    NetworkAlert(UncheckedSigned<Alert<H, D, MK::Signature>, MK::Signature>),
     MultisignedHash(Multisigned<H::Hash, MK>),
 }

--- a/consensus/src/alerts/mod.rs
+++ b/consensus/src/alerts/mod.rs
@@ -11,7 +11,7 @@ use std::ops::Deref;
 mod handler;
 mod service;
 
-pub use handler::Handler;
+pub use handler::{Error, Handler};
 pub use service::{Service, IO};
 
 pub type ForkProof<H, D, S> = (UncheckedSignedUnit<H, D, S>, UncheckedSignedUnit<H, D, S>);

--- a/consensus/src/backup/injector.rs
+++ b/consensus/src/backup/injector.rs
@@ -17,7 +17,6 @@ use std::{
     marker::PhantomData,
     time::Duration,
 };
-use log::error;
 
 #[derive(Debug)]
 pub enum Error {
@@ -132,8 +131,6 @@ impl<H: Hasher, D: Data, MK: MultiKeychain> BackupInjector<H, D, MK> {
         let mut fork_proofs = HashMap::new();
         let mut rmcs = HashSet::new();
 
-        error!(target: "SIEMA", "read {:?} items", backup_data.len());
-
         for item in backup_data {
             match item {
                 BackupItem::Unit(unit) => {
@@ -224,8 +221,6 @@ impl<H: Hasher, D: Data, MK: MultiKeychain> BackupInjector<H, D, MK> {
         }
 
         let scheduler = DoublingDelayScheduler::with_tasks(tasks, Duration::from_millis(500));
-
-        error!(target: "SIEMA", "injected items");
 
         Ok(InitialState {
             alerter_handler,

--- a/consensus/src/backup/injector.rs
+++ b/consensus/src/backup/injector.rs
@@ -4,24 +4,19 @@ use std::{
 use std::marker::PhantomData;
 use std::time::Duration;
 use log::error;
-use crate::{alerts::{AlertData, ForkingNotification, Handler as AlerterHandler}, backup::{BackupItem}, units::{UncheckedSignedUnit, UnitCoord}, Data, Hasher, MultiKeychain, NodeIndex, SessionId, Multisigned};
+use crate::{alerts::{AlertData, ForkingNotification, Handler as AlerterHandler}, backup::{BackupItem}, units::{UncheckedSignedUnit, UnitCoord}, Data, Hasher, MultiKeychain, SessionId, Multisigned};
 use aleph_bft_rmc::{DoublingDelayScheduler, Handler as RmcHandler, Message as RmcMessage, OnStartRmcResponse};
 use aleph_bft_types::{FinalizationHandler};
-use crate::alerts::ForkProof;
 use crate::runway::Runway;
 use crate::units::SignedUnit;
 
 const LOG_TARGET: &str = "AlephBFT-backup-injector";
 
-pub struct BackupInjectError {
-
-}
-
 pub struct InitialState<H: Hasher, D: Data, MK: MultiKeychain> {
-    alerter_handler: AlerterHandler<H, D, MK>,
-    rmc_handler: RmcHandler<H::Hash, MK>,
-    forking_notifications: Vec<ForkingNotification<H, D, MK::Signature>>,
-    scheduler: DoublingDelayScheduler<RmcMessage<H::Hash, MK::Signature, MK::PartialMultisignature>>,
+    pub alerter_handler: AlerterHandler<H, D, MK>,
+    pub rmc_handler: RmcHandler<H::Hash, MK>,
+    pub forking_notifications: Vec<ForkingNotification<H, D, MK::Signature>>,
+    pub scheduler: DoublingDelayScheduler<RmcMessage<H::Hash, MK::Signature, MK::PartialMultisignature>>,
 }
 
 pub struct BackupInjector<H: Hasher, D: Data, MK: MultiKeychain> {

--- a/consensus/src/backup/injector.rs
+++ b/consensus/src/backup/injector.rs
@@ -1,0 +1,201 @@
+use std::{
+    collections::{HashMap, HashSet},
+};
+use std::time::Duration;
+use log::error;
+use crate::{alerts::{AlertData, ForkingNotification, Handler as AlerterHandler}, backup::{BackupItem}, units::{UncheckedSignedUnit, UnitCoord}, Data, Hasher, MultiKeychain, NodeIndex, SessionId, Multisigned};
+use aleph_bft_rmc::{DoublingDelayScheduler, Handler as RmcHandler, Message as RmcMessage, OnStartRmcResponse};
+use aleph_bft_types::{FinalizationHandler};
+use crate::alerts::ForkProof;
+use crate::runway::Runway;
+use crate::units::SignedUnit;
+
+const LOG_TARGET: &str = "AlephBFT-backup-injector";
+
+pub struct BackupInjectError {
+
+}
+
+pub struct InitialState<H: Hasher, D: Data, MK: MultiKeychain> {
+    alerter_handler: AlerterHandler<H, D, MK>,
+    rmc_handler: RmcHandler<H::Hash, MK>,
+    forking_notifications: Vec<ForkingNotification<H, D, MK::Signature>>,
+    scheduler: DoublingDelayScheduler<RmcMessage<H::Hash, MK::Signature, MK::PartialMultisignature>>,
+}
+
+pub struct BackupInjector<H: Hasher, D: Data, MK: MultiKeychain> {
+    backup_data: Vec<BackupItem<H, D, MK>>,
+    session_id: SessionId,
+    keychain: MK,
+    dag: HashSet<UnitCoord>,
+    fork_proofs: HashMap<NodeIndex, ForkProof<H, D, MK::Signature>>,
+    rmcs: HashSet<H::Hash>,
+}
+
+impl<H: Hasher, D: Data, MK: MultiKeychain> BackupInjector<H, D, MK> {
+    pub fn new(
+        backup_data: Vec<BackupItem<H, D, MK>>,
+        session_id: SessionId,
+        keychain: MK,
+    ) -> Self {
+        BackupInjector {
+            backup_data,
+            session_id,
+            keychain,
+            dag: HashSet::new(),
+            fork_proofs: HashMap::new(),
+            rmcs: HashSet::new(),
+        }
+    }
+
+    fn verify_unit_parents(&self, unit: &UncheckedSignedUnit<H, D, MK::Signature>) -> bool {
+        let full_unit = unit.as_signable();
+        let coord = full_unit.coord();
+        if full_unit.session_id() != self.session_id {
+            return false;
+        }
+        let parent_ids = &full_unit.as_pre_unit().control_hash().parents_mask;
+        for parent_id in parent_ids.elements() {
+            let parent = UnitCoord::new(coord.round() - 1, parent_id);
+            if !self.dag.contains(&parent) {
+                return false;
+            }
+        }
+        true
+    }
+
+    fn handle_multisigned(&self, multisigned: Multisigned<H::Hash, MK>, alerter_handler: &mut AlerterHandler<H, D, MK>) -> Option<Vec<SignedUnit<H, D, MK>>> {
+        match alerter_handler.alert_confirmed(multisigned) {
+            Ok(units) => {
+                let mut signed_units = vec![];
+                for unit in units {
+                    // we don't verify parenthood as the units may come from the future
+                    let signed_unit = match unit.check(&self.keychain) {
+                        Ok(su) => su,
+                        Err(e) => {
+                            error!(target: LOG_TARGET, "error when checking unit: {:?}.", e);
+                            return None
+                        },
+                    };
+                    signed_units.push(signed_unit);
+                }
+                Some(signed_units)
+            }
+            Err(e) => {
+                error!(target: LOG_TARGET, "error when handling multisigned by alerter: {:?}.", e);
+                None
+            },
+        }
+    }
+
+    pub fn get_initial_state<FH: FinalizationHandler<D>>(mut self, runway: &mut Runway<H, D, FH, MK>) -> Option<InitialState<H, D, MK>> {
+        let mut alerter_handler = AlerterHandler::new(self.keychain.clone(), self.session_id);
+        let mut rmc_handler = RmcHandler::new(self.keychain.clone());
+
+        for item in self.backup_data {
+            match item {
+                BackupItem::Unit(unit) => {
+                    if !self.verify_unit_parents(&unit) {
+                        // TODO error
+                    }
+                    let signed_unit = match unit.check(&self.keychain) {
+                        Ok(su) => su,
+                        Err(e) => panic!("error"), // TODO error
+                    };
+
+                    // in self.dag we store units which were saved as the Unit variant of BackupData
+                    // we require that there is no fork in this data, as all of the forking units
+                    // are assumed to be stored as legit units of backed up alerts
+                    if self.dag.contains(&unit.as_signable().coord()) {
+                        // TODO error fork
+                    }
+
+                    runway.add_unit(signed_unit, false); // synchronous simulation
+                    self.dag.insert(unit.as_signable().coord());
+                }
+                BackupItem::AlertData(AlertData::OwnAlert(alert)) => {
+                    let alert = match alert.check(&self.keychain) {
+                        Ok(alert) => alert.into_signable(),
+                        Err(e) => panic!("err"), // TODO Error
+                    };
+
+                    // synchronous simulation
+                    let (_, hash) = alerter_handler.on_own_alert(alert);
+                    runway.mark_forker(alert.forker());
+
+                    // we don't want to send the notification to runway as it would create
+                    // a duplicate alert about the forker and pass it to the alerter
+                    self.fork_proofs.remove(&alert.forker());
+
+                    // we may want to start rmc at the end, if we don't encounter the
+                    // corresponding multisignature in the backup
+                    self.rmcs.insert(hash);
+                },
+                BackupItem::AlertData(AlertData::NetworkAlert(alert)) => {
+                    if let Ok((Some(proof), hash)) =
+                        alerter_handler.on_network_alert(alert) // synchronous simulation
+                    {
+                        // runway has to know the forker from its storage
+                        runway.mark_forker(alert.as_signable().forker());
+
+                        // we may want to pass this proof to runway after the
+                        // simulation so that it creates an appropriate alert and
+                        // passes it to the alerter, but only if we can't find
+                        // an alert corresponding to this forker in the backup
+                        self.fork_proofs
+                            .insert(alert.as_signable().forker(), proof);
+
+                        // similarly, we may need to start rmc on the hash
+                        self.rmcs.insert(hash);
+                    }
+                },
+                BackupItem::AlertData(AlertData::MultisignedHash(multisigned)) => {
+                    if rmc_handler.on_multisigned_hash(multisigned.into_unchecked()).is_err() {
+                        // TODO error bad multisig
+                    }
+
+                    let legit_units = match self.handle_multisigned(multisigned, &mut alerter_handler) {
+                        Some(units) => units,
+                        None => return None,
+                    };
+                    for unit in legit_units {
+                        runway.add_unit(unit, true);
+                    }
+
+                    // we don't need to start rmc on this hash as we already have the multisignature
+                    self.rmcs.remove(multisigned.as_signable());
+                }
+            }
+        }
+
+        let mut tasks = vec![];
+        for hash in self.rmcs {
+            match rmc_handler.on_start_rmc(hash) {
+                OnStartRmcResponse::SignedHash(signed) => {
+                    tasks.push(RmcMessage::SignedHash(signed.into_unchecked()));
+                }
+                OnStartRmcResponse::MultisignedHash(multisigned) => {
+                    tasks.push(RmcMessage::MultisignedHash(multisigned.into_unchecked()));
+                    let legit_units = match self.handle_multisigned(multisigned, &mut alerter_handler) {
+                        Some(units) => units,
+                        None => return None,
+                    };
+                    for unit in legit_units {
+                        runway.add_unit(unit, true);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let scheduler = DoublingDelayScheduler::with_tasks(tasks, Duration::from_millis(500));
+
+        Some(InitialState {
+            alerter_handler,
+            rmc_handler,
+            forking_notifications:
+            self.fork_proofs.into_values().map(|p| ForkingNotification::Forker(p)).collect(),
+            scheduler,
+        })
+    }
+}

--- a/consensus/src/backup/injector.rs
+++ b/consensus/src/backup/injector.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{HashMap, HashSet},
 };
+use std::marker::PhantomData;
 use std::time::Duration;
 use log::error;
 use crate::{alerts::{AlertData, ForkingNotification, Handler as AlerterHandler}, backup::{BackupItem}, units::{UncheckedSignedUnit, UnitCoord}, Data, Hasher, MultiKeychain, NodeIndex, SessionId, Multisigned};
@@ -24,27 +25,22 @@ pub struct InitialState<H: Hasher, D: Data, MK: MultiKeychain> {
 }
 
 pub struct BackupInjector<H: Hasher, D: Data, MK: MultiKeychain> {
-    backup_data: Vec<BackupItem<H, D, MK>>,
     session_id: SessionId,
     keychain: MK,
     dag: HashSet<UnitCoord>,
-    fork_proofs: HashMap<NodeIndex, ForkProof<H, D, MK::Signature>>,
-    rmcs: HashSet<H::Hash>,
+    _phantom: PhantomData<(H, D)>,
 }
 
 impl<H: Hasher, D: Data, MK: MultiKeychain> BackupInjector<H, D, MK> {
     pub fn new(
-        backup_data: Vec<BackupItem<H, D, MK>>,
         session_id: SessionId,
         keychain: MK,
     ) -> Self {
         BackupInjector {
-            backup_data,
             session_id,
             keychain,
             dag: HashSet::new(),
-            fork_proofs: HashMap::new(),
-            rmcs: HashSet::new(),
+            _phantom: PhantomData,
         }
     }
 
@@ -52,12 +48,14 @@ impl<H: Hasher, D: Data, MK: MultiKeychain> BackupInjector<H, D, MK> {
         let full_unit = unit.as_signable();
         let coord = full_unit.coord();
         if full_unit.session_id() != self.session_id {
+            error!(target: LOG_TARGET, "unit of wrong session in the backup.");
             return false;
         }
         let parent_ids = &full_unit.as_pre_unit().control_hash().parents_mask;
         for parent_id in parent_ids.elements() {
             let parent = UnitCoord::new(coord.round() - 1, parent_id);
             if !self.dag.contains(&parent) {
+                error!(target: LOG_TARGET, "parent of a unit missing from the backup.");
                 return false;
             }
         }
@@ -88,73 +86,87 @@ impl<H: Hasher, D: Data, MK: MultiKeychain> BackupInjector<H, D, MK> {
         }
     }
 
-    pub fn get_initial_state<FH: FinalizationHandler<D>>(mut self, runway: &mut Runway<H, D, FH, MK>) -> Option<InitialState<H, D, MK>> {
+    pub fn get_initial_state<FH: FinalizationHandler<D>>(mut self, backup_data: Vec<BackupItem<H, D, MK>>,  runway: &mut Runway<H, D, FH, MK>) -> Option<InitialState<H, D, MK>> {
         let mut alerter_handler = AlerterHandler::new(self.keychain.clone(), self.session_id);
         let mut rmc_handler = RmcHandler::new(self.keychain.clone());
+        let mut fork_proofs = HashMap::new();
+        let mut rmcs = HashSet::new();
 
-        for item in self.backup_data {
+        for item in backup_data {
             match item {
                 BackupItem::Unit(unit) => {
                     if !self.verify_unit_parents(&unit) {
-                        // TODO error
+                        return None;
                     }
                     let signed_unit = match unit.check(&self.keychain) {
                         Ok(su) => su,
-                        Err(e) => panic!("error"), // TODO error
+                        Err(e) => {
+                            error!(target: LOG_TARGET, "error when checking unit: {:?}.", e);
+                            return None;
+                        }
                     };
 
                     // in self.dag we store units which were saved as the Unit variant of BackupData
                     // we require that there is no fork in this data, as all of the forking units
                     // are assumed to be stored as legit units of backed up alerts
-                    if self.dag.contains(&unit.as_signable().coord()) {
-                        // TODO error fork
+                    let coord = signed_unit.as_signable().coord();
+                    if self.dag.contains(&coord) {
+                        error!(target: LOG_TARGET, "forking unit in backup not coming from alert.");
+                        return None;
                     }
 
                     runway.add_unit(signed_unit, false); // synchronous simulation
-                    self.dag.insert(unit.as_signable().coord());
+                    self.dag.insert(coord);
                 }
                 BackupItem::AlertData(AlertData::OwnAlert(alert)) => {
                     let alert = match alert.check(&self.keychain) {
                         Ok(alert) => alert.into_signable(),
-                        Err(e) => panic!("err"), // TODO Error
+                        Err(e) => {
+                            error!(target: LOG_TARGET, "error when checking unit: {:?}.", e);
+                            error!(target: LOG_TARGET, "error when checking alert: {:?}.", e);
+                            return None;
+                        }
                     };
 
                     // synchronous simulation
-                    let (_, hash) = alerter_handler.on_own_alert(alert);
-                    runway.mark_forker(alert.forker());
+                    let hash = alert.hash();
+                    let forker = alert.forker();
+                    let _ = alerter_handler.on_own_alert(alert);
+                    runway.mark_forker(forker);
 
                     // we don't want to send the notification to runway as it would create
                     // a duplicate alert about the forker and pass it to the alerter
-                    self.fork_proofs.remove(&alert.forker());
+                    fork_proofs.remove(&forker);
 
                     // we may want to start rmc at the end, if we don't encounter the
                     // corresponding multisignature in the backup
-                    self.rmcs.insert(hash);
+                    rmcs.insert(hash);
                 },
                 BackupItem::AlertData(AlertData::NetworkAlert(alert)) => {
+                    let forker = alert.as_signable().forker();
                     if let Ok((Some(proof), hash)) =
                         alerter_handler.on_network_alert(alert) // synchronous simulation
                     {
                         // runway has to know the forker from its storage
-                        runway.mark_forker(alert.as_signable().forker());
+                        runway.mark_forker(forker);
 
                         // we may want to pass this proof to runway after the
                         // simulation so that it creates an appropriate alert and
                         // passes it to the alerter, but only if we can't find
                         // an alert corresponding to this forker in the backup
-                        self.fork_proofs
-                            .insert(alert.as_signable().forker(), proof);
+                        fork_proofs
+                            .insert(forker, proof);
 
                         // similarly, we may need to start rmc on the hash
-                        self.rmcs.insert(hash);
+                        rmcs.insert(hash);
                     }
                 },
                 BackupItem::AlertData(AlertData::MultisignedHash(multisigned)) => {
-                    if rmc_handler.on_multisigned_hash(multisigned.into_unchecked()).is_err() {
-                        // TODO error bad multisig
+                    if let Err(e) = rmc_handler.on_multisigned_hash(multisigned.clone().into_unchecked()) {
+                        error!(target: LOG_TARGET, "error when checking multisigned: {:?}.", e);
                     }
 
-                    let legit_units = match self.handle_multisigned(multisigned, &mut alerter_handler) {
+                    let legit_units = match self.handle_multisigned(multisigned.clone(), &mut alerter_handler) {
                         Some(units) => units,
                         None => return None,
                     };
@@ -163,19 +175,19 @@ impl<H: Hasher, D: Data, MK: MultiKeychain> BackupInjector<H, D, MK> {
                     }
 
                     // we don't need to start rmc on this hash as we already have the multisignature
-                    self.rmcs.remove(multisigned.as_signable());
+                    rmcs.remove(multisigned.as_signable());
                 }
             }
         }
 
         let mut tasks = vec![];
-        for hash in self.rmcs {
+        for hash in rmcs {
             match rmc_handler.on_start_rmc(hash) {
                 OnStartRmcResponse::SignedHash(signed) => {
                     tasks.push(RmcMessage::SignedHash(signed.into_unchecked()));
                 }
                 OnStartRmcResponse::MultisignedHash(multisigned) => {
-                    tasks.push(RmcMessage::MultisignedHash(multisigned.into_unchecked()));
+                    tasks.push(RmcMessage::MultisignedHash(multisigned.clone().into_unchecked()));
                     let legit_units = match self.handle_multisigned(multisigned, &mut alerter_handler) {
                         Some(units) => units,
                         None => return None,
@@ -194,7 +206,7 @@ impl<H: Hasher, D: Data, MK: MultiKeychain> BackupInjector<H, D, MK> {
             alerter_handler,
             rmc_handler,
             forking_notifications:
-            self.fork_proofs.into_values().map(|p| ForkingNotification::Forker(p)).collect(),
+            fork_proofs.into_values().collect(),
             scheduler,
         })
     }

--- a/consensus/src/backup/injector.rs
+++ b/consensus/src/backup/injector.rs
@@ -17,6 +17,7 @@ use std::{
     marker::PhantomData,
     time::Duration,
 };
+use log::error;
 
 #[derive(Debug)]
 pub enum Error {
@@ -131,6 +132,8 @@ impl<H: Hasher, D: Data, MK: MultiKeychain> BackupInjector<H, D, MK> {
         let mut fork_proofs = HashMap::new();
         let mut rmcs = HashSet::new();
 
+        error!(target: "SIEMA", "read {:?} items", backup_data.len());
+
         for item in backup_data {
             match item {
                 BackupItem::Unit(unit) => {
@@ -221,6 +224,8 @@ impl<H: Hasher, D: Data, MK: MultiKeychain> BackupInjector<H, D, MK> {
         }
 
         let scheduler = DoublingDelayScheduler::with_tasks(tasks, Duration::from_millis(500));
+
+        error!(target: "SIEMA", "injected items");
 
         Ok(InitialState {
             alerter_handler,

--- a/consensus/src/backup/injector.rs
+++ b/consensus/src/backup/injector.rs
@@ -1,22 +1,73 @@
+use crate::{
+    alerts::{AlertData, Error as AlerterError, ForkingNotification, Handler as AlerterHandler},
+    backup::BackupItem,
+    runway::Runway,
+    units::{SignedUnit, UncheckedSignedUnit, UnitCoord},
+    Data, Hasher, MultiKeychain, Multisigned, SessionId,
+};
+use aleph_bft_rmc::{
+    DoublingDelayScheduler, Error as RmcError, Handler as RmcHandler, Message as RmcMessage,
+    OnStartRmcResponse,
+};
+use aleph_bft_types::FinalizationHandler;
 use std::{
     collections::{HashMap, HashSet},
+    fmt,
+    fmt::{Display, Formatter},
+    marker::PhantomData,
+    time::Duration,
 };
-use std::marker::PhantomData;
-use std::time::Duration;
-use log::error;
-use crate::{alerts::{AlertData, ForkingNotification, Handler as AlerterHandler}, backup::{BackupItem}, units::{UncheckedSignedUnit, UnitCoord}, Data, Hasher, MultiKeychain, SessionId, Multisigned};
-use aleph_bft_rmc::{DoublingDelayScheduler, Handler as RmcHandler, Message as RmcMessage, OnStartRmcResponse};
-use aleph_bft_types::{FinalizationHandler};
-use crate::runway::Runway;
-use crate::units::SignedUnit;
 
-const LOG_TARGET: &str = "AlephBFT-backup-injector";
+#[derive(Debug)]
+pub enum Error {
+    WrongSession(SessionId, SessionId),
+    ParentMissing,
+    ForkInUnitBackup,
+    BadUnit,
+    BadAlert,
+    AlerterHandler(AlerterError),
+    RmcHandler(RmcError),
+}
+
+impl From<AlerterError> for Error {
+    fn from(error: AlerterError) -> Self {
+        Error::AlerterHandler(error)
+    }
+}
+
+impl From<RmcError> for Error {
+    fn from(error: RmcError) -> Self {
+        Error::RmcHandler(error)
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::WrongSession(actual, expected) => write!(
+                f,
+                "found unit of wrong session ({:?}) in backup for session {:?}.",
+                actual, expected
+            ),
+            Error::ParentMissing => write!(f, "parent of a unit missing from the backup."),
+            Error::ForkInUnitBackup => write!(
+                f,
+                "forking units not coming from alerts found in the backup."
+            ),
+            Error::BadUnit => write!(f, "wrongly signed unit found in the backup."),
+            Error::BadAlert => write!(f, "wrongly signed alert found in the backup."),
+            Error::AlerterHandler(e) => write!(f, "error in alerter handler: {:?}.", e),
+            Error::RmcHandler(e) => write!(f, "error in rmc handler: {:?}.", e),
+        }
+    }
+}
 
 pub struct InitialState<H: Hasher, D: Data, MK: MultiKeychain> {
     pub alerter_handler: AlerterHandler<H, D, MK>,
     pub rmc_handler: RmcHandler<H::Hash, MK>,
     pub forking_notifications: Vec<ForkingNotification<H, D, MK::Signature>>,
-    pub scheduler: DoublingDelayScheduler<RmcMessage<H::Hash, MK::Signature, MK::PartialMultisignature>>,
+    pub scheduler:
+        DoublingDelayScheduler<RmcMessage<H::Hash, MK::Signature, MK::PartialMultisignature>>,
 }
 
 pub struct BackupInjector<H: Hasher, D: Data, MK: MultiKeychain> {
@@ -27,10 +78,7 @@ pub struct BackupInjector<H: Hasher, D: Data, MK: MultiKeychain> {
 }
 
 impl<H: Hasher, D: Data, MK: MultiKeychain> BackupInjector<H, D, MK> {
-    pub fn new(
-        session_id: SessionId,
-        keychain: MK,
-    ) -> Self {
+    pub fn new(session_id: SessionId, keychain: MK) -> Self {
         BackupInjector {
             session_id,
             keychain,
@@ -39,49 +87,45 @@ impl<H: Hasher, D: Data, MK: MultiKeychain> BackupInjector<H, D, MK> {
         }
     }
 
-    fn verify_unit_parents(&self, unit: &UncheckedSignedUnit<H, D, MK::Signature>) -> bool {
+    fn verify_unit_parents(
+        &self,
+        unit: &UncheckedSignedUnit<H, D, MK::Signature>,
+    ) -> Result<(), Error> {
         let full_unit = unit.as_signable();
         let coord = full_unit.coord();
         if full_unit.session_id() != self.session_id {
-            error!(target: LOG_TARGET, "unit of wrong session in the backup.");
-            return false;
+            return Err(Error::WrongSession(full_unit.session_id(), self.session_id));
         }
         let parent_ids = &full_unit.as_pre_unit().control_hash().parents_mask;
         for parent_id in parent_ids.elements() {
             let parent = UnitCoord::new(coord.round() - 1, parent_id);
             if !self.dag.contains(&parent) {
-                error!(target: LOG_TARGET, "parent of a unit missing from the backup.");
-                return false;
+                return Err(Error::ParentMissing);
             }
         }
-        true
+        Ok(())
     }
 
-    fn handle_multisigned(&self, multisigned: Multisigned<H::Hash, MK>, alerter_handler: &mut AlerterHandler<H, D, MK>) -> Option<Vec<SignedUnit<H, D, MK>>> {
-        match alerter_handler.alert_confirmed(multisigned) {
-            Ok(units) => {
-                let mut signed_units = vec![];
-                for unit in units {
-                    // we don't verify parenthood as the units may come from the future
-                    let signed_unit = match unit.check(&self.keychain) {
-                        Ok(su) => su,
-                        Err(e) => {
-                            error!(target: LOG_TARGET, "error when checking unit: {:?}.", e);
-                            return None
-                        },
-                    };
-                    signed_units.push(signed_unit);
-                }
-                Some(signed_units)
-            }
-            Err(e) => {
-                error!(target: LOG_TARGET, "error when handling multisigned by alerter: {:?}.", e);
-                None
-            },
+    fn handle_multisigned(
+        &self,
+        multisigned: Multisigned<H::Hash, MK>,
+        alerter_handler: &mut AlerterHandler<H, D, MK>,
+    ) -> Result<Vec<SignedUnit<H, D, MK>>, Error> {
+        let units = alerter_handler.alert_confirmed(multisigned)?;
+        let mut signed_units = vec![];
+        for unit in units {
+            // we don't verify parenthood as the units may come from the future
+            let signed_unit = unit.check(&self.keychain).map_err(|_| Error::BadUnit)?;
+            signed_units.push(signed_unit);
         }
+        Ok(signed_units)
     }
 
-    pub fn get_initial_state<FH: FinalizationHandler<D>>(mut self, backup_data: Vec<BackupItem<H, D, MK>>,  runway: &mut Runway<H, D, FH, MK>) -> Option<InitialState<H, D, MK>> {
+    pub fn get_initial_state<FH: FinalizationHandler<D>>(
+        mut self,
+        backup_data: Vec<BackupItem<H, D, MK>>,
+        runway: &mut Runway<H, D, FH, MK>,
+    ) -> Result<InitialState<H, D, MK>, Error> {
         let mut alerter_handler = AlerterHandler::new(self.keychain.clone(), self.session_id);
         let mut rmc_handler = RmcHandler::new(self.keychain.clone());
         let mut fork_proofs = HashMap::new();
@@ -90,38 +134,25 @@ impl<H: Hasher, D: Data, MK: MultiKeychain> BackupInjector<H, D, MK> {
         for item in backup_data {
             match item {
                 BackupItem::Unit(unit) => {
-                    if !self.verify_unit_parents(&unit) {
-                        return None;
-                    }
-                    let signed_unit = match unit.check(&self.keychain) {
-                        Ok(su) => su,
-                        Err(e) => {
-                            error!(target: LOG_TARGET, "error when checking unit: {:?}.", e);
-                            return None;
-                        }
-                    };
+                    self.verify_unit_parents(&unit)?;
+                    let signed_unit = unit.check(&self.keychain).map_err(|_| Error::BadUnit)?;
 
                     // in self.dag we store units which were saved as the Unit variant of BackupData
                     // we require that there is no fork in this data, as all of the forking units
                     // are assumed to be stored as legit units of backed up alerts
                     let coord = signed_unit.as_signable().coord();
                     if self.dag.contains(&coord) {
-                        error!(target: LOG_TARGET, "forking unit in backup not coming from alert.");
-                        return None;
+                        return Err(Error::ForkInUnitBackup);
                     }
 
                     runway.add_unit(signed_unit, false); // synchronous simulation
                     self.dag.insert(coord);
                 }
                 BackupItem::AlertData(AlertData::OwnAlert(alert)) => {
-                    let alert = match alert.check(&self.keychain) {
-                        Ok(alert) => alert.into_signable(),
-                        Err(e) => {
-                            error!(target: LOG_TARGET, "error when checking unit: {:?}.", e);
-                            error!(target: LOG_TARGET, "error when checking alert: {:?}.", e);
-                            return None;
-                        }
-                    };
+                    let alert = alert
+                        .check(&self.keychain)
+                        .map_err(|_| Error::BadAlert)?
+                        .into_signable();
 
                     // synchronous simulation
                     let hash = alert.hash();
@@ -136,11 +167,11 @@ impl<H: Hasher, D: Data, MK: MultiKeychain> BackupInjector<H, D, MK> {
                     // we may want to start rmc at the end, if we don't encounter the
                     // corresponding multisignature in the backup
                     rmcs.insert(hash);
-                },
+                }
                 BackupItem::AlertData(AlertData::NetworkAlert(alert)) => {
                     let forker = alert.as_signable().forker();
-                    if let Ok((Some(proof), hash)) =
-                        alerter_handler.on_network_alert(alert) // synchronous simulation
+                    if let Ok((Some(proof), hash)) = alerter_handler.on_network_alert(alert)
+                    // synchronous simulation
                     {
                         // runway has to know the forker from its storage
                         runway.mark_forker(forker);
@@ -149,22 +180,17 @@ impl<H: Hasher, D: Data, MK: MultiKeychain> BackupInjector<H, D, MK> {
                         // simulation so that it creates an appropriate alert and
                         // passes it to the alerter, but only if we can't find
                         // an alert corresponding to this forker in the backup
-                        fork_proofs
-                            .insert(forker, proof);
+                        fork_proofs.insert(forker, proof);
 
                         // similarly, we may need to start rmc on the hash
                         rmcs.insert(hash);
                     }
-                },
+                }
                 BackupItem::AlertData(AlertData::MultisignedHash(multisigned)) => {
-                    if let Err(e) = rmc_handler.on_multisigned_hash(multisigned.clone().into_unchecked()) {
-                        error!(target: LOG_TARGET, "error when checking multisigned: {:?}.", e);
-                    }
+                    rmc_handler.on_multisigned_hash(multisigned.clone().into_unchecked())?;
 
-                    let legit_units = match self.handle_multisigned(multisigned.clone(), &mut alerter_handler) {
-                        Some(units) => units,
-                        None => return None,
-                    };
+                    let legit_units =
+                        self.handle_multisigned(multisigned.clone(), &mut alerter_handler)?;
                     for unit in legit_units {
                         runway.add_unit(unit, true);
                     }
@@ -182,11 +208,10 @@ impl<H: Hasher, D: Data, MK: MultiKeychain> BackupInjector<H, D, MK> {
                     tasks.push(RmcMessage::SignedHash(signed.into_unchecked()));
                 }
                 OnStartRmcResponse::MultisignedHash(multisigned) => {
-                    tasks.push(RmcMessage::MultisignedHash(multisigned.clone().into_unchecked()));
-                    let legit_units = match self.handle_multisigned(multisigned, &mut alerter_handler) {
-                        Some(units) => units,
-                        None => return None,
-                    };
+                    tasks.push(RmcMessage::MultisignedHash(
+                        multisigned.clone().into_unchecked(),
+                    ));
+                    let legit_units = self.handle_multisigned(multisigned, &mut alerter_handler)?;
                     for unit in legit_units {
                         runway.add_unit(unit, true);
                     }
@@ -197,11 +222,10 @@ impl<H: Hasher, D: Data, MK: MultiKeychain> BackupInjector<H, D, MK> {
 
         let scheduler = DoublingDelayScheduler::with_tasks(tasks, Duration::from_millis(500));
 
-        Some(InitialState {
+        Ok(InitialState {
             alerter_handler,
             rmc_handler,
-            forking_notifications:
-            fork_proofs.into_values().collect(),
+            forking_notifications: fork_proofs.into_values().collect(),
             scheduler,
         })
     }

--- a/consensus/src/backup/mod.rs
+++ b/consensus/src/backup/mod.rs
@@ -2,14 +2,14 @@ use codec::{Decode, Encode};
 use std::fmt::Debug;
 
 pub use injector::{BackupInjector, InitialState};
-pub use loader::{BackupLoader};
+pub use loader::BackupLoader;
 pub use saver::BackupSaver;
 
 use crate::{alerts::AlertData, units::UncheckedSignedUnit, Data, Hasher, MultiKeychain};
 
+mod injector;
 mod loader;
 mod saver;
-mod injector;
 
 #[derive(Clone, Debug, Decode, Encode, PartialEq)]
 pub enum BackupItem<H: Hasher, D: Data, MK: MultiKeychain> {

--- a/consensus/src/backup/mod.rs
+++ b/consensus/src/backup/mod.rs
@@ -8,6 +8,7 @@ use crate::{alerts::AlertData, units::UncheckedSignedUnit, Data, Hasher, MultiKe
 
 mod loader;
 mod saver;
+mod injector;
 
 #[derive(Clone, Debug, Decode, Encode, PartialEq)]
 pub enum BackupItem<H: Hasher, D: Data, MK: MultiKeychain> {

--- a/consensus/src/backup/mod.rs
+++ b/consensus/src/backup/mod.rs
@@ -1,7 +1,8 @@
 use codec::{Decode, Encode};
 use std::fmt::Debug;
 
-pub use loader::{BackupLoader, LoadedData};
+pub use injector::{BackupInjector, InitialState};
+pub use loader::{BackupLoader};
 pub use saver::BackupSaver;
 
 use crate::{alerts::AlertData, units::UncheckedSignedUnit, Data, Hasher, MultiKeychain};

--- a/consensus/src/backup/saver.rs
+++ b/consensus/src/backup/saver.rs
@@ -6,10 +6,9 @@ use futures::{FutureExt, StreamExt};
 use log::{debug, error};
 
 use crate::{
-    alerts::AlertData, backup::BackupItem, units::UncheckedSignedUnit, Data, Hasher, MultiKeychain,
+    alerts::AlertData, backup::BackupItem, units::SignedUnit, Data, Hasher, MultiKeychain,
     Receiver, Sender,
 };
-use crate::units::SignedUnit;
 
 const LOG_TARGET: &str = "AlephBFT-backup-saver";
 
@@ -109,16 +108,15 @@ mod tests {
         StreamExt,
     };
 
-    use aleph_bft_mock::{Data, Hasher64, Keychain, Saver, Signature};
+    use aleph_bft_mock::{Data, Hasher64, Keychain, Saver};
     use aleph_bft_types::Terminator;
 
     use crate::{
         alerts::{Alert, AlertData},
         backup::BackupSaver,
-        units::{creator_set, preunit_to_unchecked_signed_unit, UncheckedSignedUnit},
+        units::{creator_set, FullUnit, SignedUnit},
         NodeCount, NodeIndex, Signed,
     };
-    use crate::units::{FullUnit, SignedUnit};
 
     type TestBackupSaver = BackupSaver<Hasher64, Data, Keychain, Saver>;
     type TestUnit = SignedUnit<Hasher64, Data, Keychain>;
@@ -197,7 +195,14 @@ mod tests {
             .collect();
         let alerts: Vec<TestAlertData> = (0..5)
             .map(|k| {
-                let alert = Alert::new(NodeIndex(0), (units[k].clone().into_unchecked(), units[k].clone().into_unchecked()), vec![]);
+                let alert = Alert::new(
+                    NodeIndex(0),
+                    (
+                        units[k].clone().into_unchecked(),
+                        units[k].clone().into_unchecked(),
+                    ),
+                    vec![],
+                );
                 let unchecked = Signed::sign(alert, &keychains[0]).into_unchecked();
                 TestAlertData::OwnAlert(unchecked)
             })

--- a/consensus/src/backup/saver.rs
+++ b/consensus/src/backup/saver.rs
@@ -111,7 +111,12 @@ mod tests {
     use aleph_bft_mock::{Data, Hasher64, Keychain, Saver, Signature};
     use aleph_bft_types::Terminator;
 
-    use crate::{alerts::{Alert, AlertData}, backup::BackupSaver, units::{creator_set, preunit_to_unchecked_signed_unit, UncheckedSignedUnit}, NodeCount, NodeIndex, Signed};
+    use crate::{
+        alerts::{Alert, AlertData},
+        backup::BackupSaver,
+        units::{creator_set, preunit_to_unchecked_signed_unit, UncheckedSignedUnit},
+        NodeCount, NodeIndex, Signed,
+    };
 
     type TestBackupSaver = BackupSaver<Hasher64, Data, Keychain, Saver>;
     type TestUnit = UncheckedSignedUnit<Hasher64, Data, Signature>;
@@ -192,11 +197,7 @@ mod tests {
             .collect();
         let alerts: Vec<TestAlertData> = (0..5)
             .map(|k| {
-                let alert = Alert::new(
-                    NodeIndex(0),
-                    (units[k].clone(), units[k].clone()),
-                    vec![],
-                );
+                let alert = Alert::new(NodeIndex(0), (units[k].clone(), units[k].clone()), vec![]);
                 let unchecked = Signed::sign(alert, &keychains[0]).into_unchecked();
                 TestAlertData::OwnAlert(unchecked)
             })

--- a/consensus/src/backup/saver.rs
+++ b/consensus/src/backup/saver.rs
@@ -111,12 +111,7 @@ mod tests {
     use aleph_bft_mock::{Data, Hasher64, Keychain, Saver, Signature};
     use aleph_bft_types::Terminator;
 
-    use crate::{
-        alerts::{Alert, AlertData},
-        backup::BackupSaver,
-        units::{creator_set, preunit_to_unchecked_signed_unit, UncheckedSignedUnit},
-        NodeCount, NodeIndex,
-    };
+    use crate::{alerts::{Alert, AlertData}, backup::BackupSaver, units::{creator_set, preunit_to_unchecked_signed_unit, UncheckedSignedUnit}, NodeCount, NodeIndex, Signed};
 
     type TestBackupSaver = BackupSaver<Hasher64, Data, Keychain, Saver>;
     type TestUnit = UncheckedSignedUnit<Hasher64, Data, Signature>;
@@ -197,11 +192,13 @@ mod tests {
             .collect();
         let alerts: Vec<TestAlertData> = (0..5)
             .map(|k| {
-                TestAlertData::OwnAlert(Alert::new(
+                let alert = Alert::new(
                     NodeIndex(0),
                     (units[k].clone(), units[k].clone()),
                     vec![],
-                ))
+                );
+                let unchecked = Signed::sign(alert, &keychains[0]).into_unchecked();
+                TestAlertData::OwnAlert(unchecked)
             })
             .collect();
 

--- a/consensus/src/backup/saver.rs
+++ b/consensus/src/backup/saver.rs
@@ -6,10 +6,9 @@ use futures::{FutureExt, StreamExt};
 use log::{debug, error};
 
 use crate::{
-    alerts::AlertData, backup::BackupItem, Data, Hasher, MultiKeychain,
+    alerts::AlertData, backup::BackupItem, units::UncheckedSignedUnit, Data, Hasher, MultiKeychain,
     Receiver, Sender,
 };
-use crate::units::SignedUnit;
 
 const LOG_TARGET: &str = "AlephBFT-backup-saver";
 
@@ -17,18 +16,18 @@ const LOG_TARGET: &str = "AlephBFT-backup-saver";
 /// It waits for items to appear on its receivers, and writes them to backup.
 /// It announces a successful write through an appropriate response sender.
 pub struct BackupSaver<H: Hasher, D: Data, MK: MultiKeychain, W: Write> {
-    units_from_runway: Receiver<SignedUnit<H, D, MK>>,
+    units_from_runway: Receiver<UncheckedSignedUnit<H, D, MK::Signature>>,
     data_from_alerter: Receiver<AlertData<H, D, MK>>,
-    responses_for_runway: Sender<SignedUnit<H, D, MK>>,
+    responses_for_runway: Sender<UncheckedSignedUnit<H, D, MK::Signature>>,
     responses_for_alerter: Sender<AlertData<H, D, MK>>,
     backup: W,
 }
 
 impl<H: Hasher, D: Data, MK: MultiKeychain, W: Write> BackupSaver<H, D, MK, W> {
     pub fn new(
-        units_from_runway: Receiver<SignedUnit<H, D, MK>>,
+        units_from_runway: Receiver<UncheckedSignedUnit<H, D, MK::Signature>>,
         data_from_alerter: Receiver<AlertData<H, D, MK>>,
-        responses_for_runway: Sender<SignedUnit<H, D, MK>>,
+        responses_for_runway: Sender<UncheckedSignedUnit<H, D, MK::Signature>>,
         responses_for_alerter: Sender<AlertData<H, D, MK>>,
         backup: W,
     ) -> BackupSaver<H, D, MK, W> {
@@ -59,7 +58,7 @@ impl<H: Hasher, D: Data, MK: MultiKeychain, W: Write> BackupSaver<H, D, MK, W> {
                             break;
                         },
                     };
-                    let item = BackupItem::Unit(unit.clone().into_unchecked());
+                    let item = BackupItem::Unit(unit.clone());
                     if let Err(e) = self.save_item(item) {
                         error!(target: LOG_TARGET, "couldn't save item to backup: {:?}", e);
                         break;
@@ -109,19 +108,18 @@ mod tests {
         StreamExt,
     };
 
-    use aleph_bft_mock::{Data, Hasher64, Keychain, Saver};
+    use aleph_bft_mock::{Data, Hasher64, Keychain, Saver, Signature};
     use aleph_bft_types::Terminator;
 
     use crate::{
         alerts::{Alert, AlertData},
         backup::BackupSaver,
-        units::{creator_set},
+        units::{creator_set, preunit_to_unchecked_signed_unit, UncheckedSignedUnit},
         NodeCount, NodeIndex, Signed,
     };
-    use crate::units::{FullUnit, SignedUnit};
 
     type TestBackupSaver = BackupSaver<Hasher64, Data, Keychain, Saver>;
-    type TestUnit = SignedUnit<Hasher64, Data, Keychain>;
+    type TestUnit = UncheckedSignedUnit<Hasher64, Data, Signature>;
     type TestAlertData = AlertData<Hasher64, Data, Keychain>;
     struct PrepareSaverResponse<F: futures::Future> {
         task: F,
@@ -190,14 +188,16 @@ mod tests {
             .collect();
         let units: Vec<TestUnit> = (0..5)
             .map(|k| {
-                let pu = creators[k].create_unit(0).unwrap().0;
-                let fu = FullUnit::new(pu, Some(0), 0);
-                Signed::sign(fu, &keychains[k])
+                preunit_to_unchecked_signed_unit(
+                    creators[k].create_unit(0).unwrap().0,
+                    0,
+                    &keychains[k],
+                )
             })
             .collect();
         let alerts: Vec<TestAlertData> = (0..5)
             .map(|k| {
-                let alert = Alert::new(NodeIndex(0), (units[k].clone().into_unchecked(), units[k].clone().into_unchecked()), vec![]);
+                let alert = Alert::new(NodeIndex(0), (units[k].clone(), units[k].clone()), vec![]);
                 let unchecked = Signed::sign(alert, &keychains[0]).into_unchecked();
                 TestAlertData::OwnAlert(unchecked)
             })

--- a/consensus/src/backup/saver.rs
+++ b/consensus/src/backup/saver.rs
@@ -9,6 +9,7 @@ use crate::{
     alerts::AlertData, backup::BackupItem, units::UncheckedSignedUnit, Data, Hasher, MultiKeychain,
     Receiver, Sender,
 };
+use crate::units::SignedUnit;
 
 const LOG_TARGET: &str = "AlephBFT-backup-saver";
 
@@ -16,18 +17,18 @@ const LOG_TARGET: &str = "AlephBFT-backup-saver";
 /// It waits for items to appear on its receivers, and writes them to backup.
 /// It announces a successful write through an appropriate response sender.
 pub struct BackupSaver<H: Hasher, D: Data, MK: MultiKeychain, W: Write> {
-    units_from_runway: Receiver<UncheckedSignedUnit<H, D, MK::Signature>>,
+    units_from_runway: Receiver<SignedUnit<H, D, MK>>,
     data_from_alerter: Receiver<AlertData<H, D, MK>>,
-    responses_for_runway: Sender<UncheckedSignedUnit<H, D, MK::Signature>>,
+    responses_for_runway: Sender<SignedUnit<H, D, MK>>,
     responses_for_alerter: Sender<AlertData<H, D, MK>>,
     backup: W,
 }
 
 impl<H: Hasher, D: Data, MK: MultiKeychain, W: Write> BackupSaver<H, D, MK, W> {
     pub fn new(
-        units_from_runway: Receiver<UncheckedSignedUnit<H, D, MK::Signature>>,
+        units_from_runway: Receiver<SignedUnit<H, D, MK>>,
         data_from_alerter: Receiver<AlertData<H, D, MK>>,
-        responses_for_runway: Sender<UncheckedSignedUnit<H, D, MK::Signature>>,
+        responses_for_runway: Sender<SignedUnit<H, D, MK>>,
         responses_for_alerter: Sender<AlertData<H, D, MK>>,
         backup: W,
     ) -> BackupSaver<H, D, MK, W> {
@@ -58,7 +59,7 @@ impl<H: Hasher, D: Data, MK: MultiKeychain, W: Write> BackupSaver<H, D, MK, W> {
                             break;
                         },
                     };
-                    let item = BackupItem::Unit(unit.clone());
+                    let item = BackupItem::Unit(unit.clone().into_unchecked());
                     if let Err(e) = self.save_item(item) {
                         error!(target: LOG_TARGET, "couldn't save item to backup: {:?}", e);
                         break;
@@ -117,9 +118,10 @@ mod tests {
         units::{creator_set, preunit_to_unchecked_signed_unit, UncheckedSignedUnit},
         NodeCount, NodeIndex, Signed,
     };
+    use crate::units::{FullUnit, SignedUnit};
 
     type TestBackupSaver = BackupSaver<Hasher64, Data, Keychain, Saver>;
-    type TestUnit = UncheckedSignedUnit<Hasher64, Data, Signature>;
+    type TestUnit = SignedUnit<Hasher64, Data, Keychain>;
     type TestAlertData = AlertData<Hasher64, Data, Keychain>;
     struct PrepareSaverResponse<F: futures::Future> {
         task: F,
@@ -188,16 +190,14 @@ mod tests {
             .collect();
         let units: Vec<TestUnit> = (0..5)
             .map(|k| {
-                preunit_to_unchecked_signed_unit(
-                    creators[k].create_unit(0).unwrap().0,
-                    0,
-                    &keychains[k],
-                )
+                let pu = creators[k].create_unit(0).unwrap().0;
+                let fu = FullUnit::new(pu, Some(0), 0);
+                Signed::sign(fu, &keychains[k])
             })
             .collect();
         let alerts: Vec<TestAlertData> = (0..5)
             .map(|k| {
-                let alert = Alert::new(NodeIndex(0), (units[k].clone(), units[k].clone()), vec![]);
+                let alert = Alert::new(NodeIndex(0), (units[k].clone().into_unchecked(), units[k].clone().into_unchecked()), vec![]);
                 let unchecked = Signed::sign(alert, &keychains[0]).into_unchecked();
                 TestAlertData::OwnAlert(unchecked)
             })

--- a/consensus/src/runway/mod.rs
+++ b/consensus/src/runway/mod.rs
@@ -409,8 +409,16 @@ where
         self.store.add_unit(su, false);
     }
 
+    pub fn add_unit(&mut self, su: SignedUnit<H, D, MK>, alert: bool) {
+        self.store.add_unit(su, alert);
+    }
+
+    pub fn mark_forker(&mut self, forker: NodeIndex) {
+        self.store.mark_forker(forker);
+    }
+
     fn on_new_forker_detected(&mut self, forker: NodeIndex, proof: ForkProof<H, D, MK::Signature>) {
-        let alerted_units = self.store.mark_forker(forker);
+        let alerted_units = self.store.mark_forker_and_return_legit_units(forker);
         let alert = self.form_alert(proof, alerted_units);
         if self.alerts_for_alerter.unbounded_send(alert).is_err() {
             warn!(target: "AlephBFT-runway", "{:?} Channel to alerter should be open", self.index());

--- a/consensus/src/runway/mod.rs
+++ b/consensus/src/runway/mod.rs
@@ -123,7 +123,7 @@ type CollectionResponse<H, D, MK> = UncheckedSigned<
     <MK as Keychain>::Signature,
 >;
 
-struct Runway<H, D, FH, MK>
+pub struct Runway<H, D, FH, MK>
 where
     H: Hasher,
     D: Data,

--- a/consensus/src/runway/mod.rs
+++ b/consensus/src/runway/mod.rs
@@ -145,8 +145,8 @@ where
     rx_consensus: Receiver<NotificationOut<H>>,
     ordered_batch_rx: Receiver<Vec<H::Hash>>,
     finalization_handler: FH,
-    backup_units_for_saver: Sender<SignedUnit<H, D, MK>>,
-    backup_units_from_saver: Receiver<SignedUnit<H, D, MK>>,
+    backup_units_for_saver: Sender<UncheckedSignedUnit<H, D, MK::Signature>>,
+    backup_units_from_saver: Receiver<UncheckedSignedUnit<H, D, MK::Signature>>,
     preunits_for_packer: Sender<PreUnit<H>>,
     signed_units_from_packer: Receiver<SignedUnit<H, D, MK>>,
     exiting: bool,
@@ -248,8 +248,8 @@ impl<'a, H: Hasher> fmt::Display for RunwayStatus<'a, H> {
 struct RunwayConfig<H: Hasher, D: Data, FH: FinalizationHandler<D>, MK: MultiKeychain> {
     max_round: Round,
     finalization_handler: FH,
-    backup_units_for_saver: Sender<SignedUnit<H, D, MK>>,
-    backup_units_from_saver: Receiver<SignedUnit<H, D, MK>>,
+    backup_units_for_saver: Sender<UncheckedSignedUnit<H, D, MK::Signature>>,
+    backup_units_from_saver: Receiver<UncheckedSignedUnit<H, D, MK::Signature>>,
     alerts_for_alerter: Sender<Alert<H, D, MK::Signature>>,
     notifications_from_alerter: Receiver<ForkingNotification<H, D, MK::Signature>>,
     tx_consensus: Sender<NotificationIn<H>>,
@@ -373,7 +373,7 @@ where
                     // Units from alerts explicitly come from forkers, and we want them anyway.
                     self.store.add_unit(su, true);
                 } else {
-                    self.send_to_backup_unless_fork(su);
+                    self.add_unit_to_store_unless_fork(su);
                 }
             }
             Err(e) => warn!(target: "AlephBFT-member", "Received unit failing validation: {}", e),
@@ -386,7 +386,7 @@ where
         }
     }
 
-    fn send_to_backup_unless_fork(&mut self, su: SignedUnit<H, D, MK>) {
+    fn add_unit_to_store_unless_fork(&mut self, su: SignedUnit<H, D, MK>) {
         let full_unit = su.as_signable();
         trace!(target: "AlephBFT-member", "{:?} Adding member unit to store {:?}", self.index(), full_unit);
         if self.store.is_forker(full_unit.creator()) {
@@ -406,7 +406,7 @@ where
             return;
         }
 
-        self.send_unit_to_backup(su);
+        self.store.add_unit(su, false);
     }
 
     pub fn add_unit(&mut self, su: SignedUnit<H, D, MK>, alert: bool) {
@@ -553,7 +553,7 @@ where
             // There might be some optimization possible here to not validate twice, but overall
             // this piece of code should be executed extremely rarely.
             self.resolve_missing_coord(&su.as_signable().coord());
-            self.send_to_backup_unless_fork(su);
+            self.add_unit_to_store_unless_fork(su);
         }
 
         if ControlHash::<H>::combine_hashes(&p_hashes_node_map) != u_control_hash {
@@ -572,9 +572,9 @@ where
         }
     }
 
-    fn on_packed(&mut self, unit: SignedUnit<H, D, MK>) {
+    fn on_packed(&mut self, signed_unit: SignedUnit<H, D, MK>) {
         debug!(target: "AlephBFT-runway", "{:?} On create notification.", self.index());
-        self.send_unit_to_backup(unit);
+        self.store.add_unit(signed_unit, false);
     }
 
     fn on_alert_notification(&mut self, notification: ForkingNotification<H, D, MK::Signature>) {
@@ -613,14 +613,12 @@ where
                 self.store.add_parents(h, p_hashes);
                 self.resolve_missing_parents(&h);
                 if let Some(su) = self.store.unit_by_hash(&h).cloned() {
-                    self.send_message_for_network(RunwayNotificationOut::NewAnyUnit(
-                        su.clone().into(),
-                    ));
-                    if su.as_signable().creator() == self.index() {
-                        trace!(target: "AlephBFT-runway", "{:?} Sending a unit {:?}.", self.index(), h);
-                        self.send_message_for_network(RunwayNotificationOut::NewSelfUnit(
-                            su.into(),
-                        ));
+                    if self
+                        .backup_units_for_saver
+                        .unbounded_send(su.into())
+                        .is_err()
+                    {
+                        error!(target: "AlephBFT-runway", "{:?} A unit couldn't be sent to backup: {:?}.", self.index(), h);
                     }
                 } else {
                     error!(target: "AlephBFT-runway", "{:?} A unit already added to DAG is not in our store: {:?}.", self.index(), h);
@@ -629,8 +627,13 @@ where
         }
     }
 
-    fn on_unit_backup_saved(&mut self, unit: SignedUnit<H, D, MK>) {
-        self.store.add_unit(unit, false);
+    fn on_unit_backup_saved(&mut self, unit: UncheckedSignedUnit<H, D, MK::Signature>) {
+        self.send_message_for_network(RunwayNotificationOut::NewAnyUnit(unit.clone()));
+
+        if unit.as_signable().creator() == self.index() {
+            trace!(target: "AlephBFT-runway", "{:?} Sending a unit {:?}.", self.index(), unit.as_signable().hash());
+            self.send_message_for_network(RunwayNotificationOut::NewSelfUnit(unit));
+        }
     }
 
     fn on_missing_coords(&mut self, mut coords: Vec<UnitCoord>) {
@@ -677,12 +680,6 @@ where
             if let Some(d) = d {
                 self.finalization_handler.data_finalized(d, creator);
             }
-        }
-    }
-
-    fn send_unit_to_backup(&self, unit: SignedUnit<H, D, MK>) {
-        if self.backup_units_for_saver.unbounded_send(unit).is_err() {
-            error!(target: "AlephBFT-runway", "a unit couldn't be sent to backup");
         }
     }
 

--- a/consensus/src/testing/alerts.rs
+++ b/consensus/src/testing/alerts.rs
@@ -5,7 +5,7 @@ use crate::{
     Signed, UncheckedSigned,
 };
 use aleph_bft_mock::{Data, Hasher64, Keychain, PartialMultisignature, Signature};
-use aleph_bft_rmc::Message as RmcMessage;
+use aleph_bft_rmc::{DoublingDelayScheduler, Handler as RmcHandler, Message as RmcMessage};
 use aleph_bft_types::Terminator;
 use futures::{
     channel::{mpsc, oneshot},
@@ -219,6 +219,8 @@ impl TestCase {
         let (data_for_backup, responses_from_backup) = mpsc::unbounded();
 
         let alerter_handler = Handler::new(keychain, 0);
+        let rmc_handler = RmcHandler::new(keychain);
+        let scheduler = DoublingDelayScheduler::new(Duration::from_millis(10));
         let mut alerter_service = Service::new(
             keychain,
             crate::alerts::IO {
@@ -230,6 +232,8 @@ impl TestCase {
                 responses_from_backup,
             },
             alerter_handler,
+            rmc_handler,
+            scheduler,
         );
 
         tokio::spawn(async move {

--- a/consensus/src/testing/mod.rs
+++ b/consensus/src/testing/mod.rs
@@ -28,7 +28,7 @@ pub type ReconnectSender = ReconnectSenderGeneric<NetworkData>;
 
 pub fn init_log() {
     let _ = env_logger::builder()
-        .filter_level(log::LevelFilter::max())
+        .filter_level(log::LevelFilter::Error)
         .is_test(true)
         .try_init();
 }

--- a/consensus/src/units/store.rs
+++ b/consensus/src/units/store.rs
@@ -166,7 +166,10 @@ impl<H: Hasher, D: Data, K: Keychain> UnitStore<H, D, K> {
 
     // Marks a node as a forker and outputs all units in store created by this node.
     // The returned vector is sorted w.r.t. increasing rounds.
-    pub(crate) fn mark_forker_and_return_legit_units(&mut self, forker: NodeIndex) -> Vec<SignedUnit<H, D, K>> {
+    pub(crate) fn mark_forker_and_return_legit_units(
+        &mut self,
+        forker: NodeIndex,
+    ) -> Vec<SignedUnit<H, D, K>> {
         if self.is_forker[forker] {
             warn!(target: "AlephBFT-unit-store", "Trying to mark the node {:?} as forker for the second time.", forker);
         }

--- a/consensus/src/units/store.rs
+++ b/consensus/src/units/store.rs
@@ -272,7 +272,7 @@ mod tests {
                 if i == 0 {
                     forker_hashes.push(unit.as_signable().hash());
                 }
-                store.add_unit(unit, false);
+                store.add_non_forking_unit(unit);
             }
         }
 
@@ -280,7 +280,7 @@ mod tests {
         for round in 4..7 {
             let unit = create_unit(round, NodeIndex(0), n_nodes, 0, &keychains[0]);
             forker_hashes.push(unit.as_signable().hash());
-            store.add_unit(unit, false);
+            store.add_non_forking_unit(unit);
         }
 
         let forker_units: Vec<_> = store

--- a/rmc/Cargo.toml
+++ b/rmc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-bft-rmc"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 authors = ["Cardinal Cryptography"]
 categories = ["algorithms", "cryptography"]

--- a/rmc/src/lib.rs
+++ b/rmc/src/lib.rs
@@ -10,7 +10,7 @@ mod handler;
 mod scheduler;
 mod service;
 
-pub use handler::Handler;
+pub use handler::{Handler, OnStartRmcResponse};
 pub use scheduler::DoublingDelayScheduler;
 pub use service::Service;
 

--- a/rmc/src/lib.rs
+++ b/rmc/src/lib.rs
@@ -10,7 +10,7 @@ mod handler;
 mod scheduler;
 mod service;
 
-pub use handler::{Handler, OnStartRmcResponse};
+pub use handler::{Error, Handler, OnStartRmcResponse};
 pub use scheduler::DoublingDelayScheduler;
 pub use service::Service;
 


### PR DESCRIPTION
Injecting loaded backup into AlephBFT components.
Added `BackupInjector` - a struct responsible for filling the initial state of AlephBFT and making components ready to start after loading data from backup. It fills `alerter_handler`, `rmc_handler` and `rmc_scheduler` with the appropriate state by simulating their execution. It also fills `runway` with its appropriate state (collection of forkers). Injector also yields the collection of forking notifications which have to be sent to the Runway.

Testing
* verified that `blockchain` and `ordering` examples work after the changes