### PR TITLE
A0-1505: terminator back in consensus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-bft"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "aleph-bft-mock",
  "aleph-bft-rmc",
@@ -162,7 +162,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-bft-types"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "aleph-bft-crypto",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,7 +79,6 @@ version = "0.0.3"
 dependencies = [
  "aleph-bft",
  "aleph-bft-mock",
- "aleph-bft-types",
  "async-trait",
  "clap 4.4.6",
  "env_logger",
@@ -119,7 +118,6 @@ dependencies = [
  "afl",
  "aleph-bft",
  "aleph-bft-mock",
- "aleph-bft-types",
  "async-trait",
  "env_logger",
  "futures",
@@ -169,9 +167,7 @@ dependencies = [
  "aleph-bft-crypto",
  "async-trait",
  "futures",
- "log",
  "parity-scale-codec",
- "tokio",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ More details are available [in the book][reference-link-implementation-details].
 - Import AlephBFT in your crate
   ```toml
   [dependencies]
-  aleph-bft = "^0.32"
+  aleph-bft = "^0.33"
   ```
 - The main entry point is the `run_session` function, which returns a Future that runs the
   consensus algorithm.

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-bft"
-version = "0.32.0"
+version = "0.33.0"
 edition = "2021"
 authors = ["Cardinal Cryptography"]
 categories = ["algorithms", "data-structures", "cryptography", "database"]
@@ -14,7 +14,7 @@ description = "AlephBFT is an asynchronous and Byzantine fault tolerant consensu
 
 [dependencies]
 aleph-bft-rmc = { path = "../rmc", version = "0.11" }
-aleph-bft-types = { path = "../types", version = "0.10" }
+aleph-bft-types = { path = "../types", version = "0.11" }
 anyhow = "1.0"
 async-trait = "0.1"
 codec = { package = "parity-scale-codec", version = "3.0", default-features = false, features = ["derive"] }

--- a/consensus/src/alerts/service.rs
+++ b/consensus/src/alerts/service.rs
@@ -3,10 +3,9 @@ use crate::{
         handler::{Handler, RmcResponse},
         Alert, AlertMessage, ForkingNotification, NetworkMessage,
     },
-    Data, Hasher, MultiKeychain, Multisigned, NodeIndex, Receiver, Recipient, Sender,
+    Data, Hasher, MultiKeychain, Multisigned, NodeIndex, Receiver, Recipient, Sender, Terminator,
 };
 use aleph_bft_rmc::{DoublingDelayScheduler, Message as RmcMessage};
-use aleph_bft_types::Terminator;
 use futures::{FutureExt, StreamExt};
 use log::{debug, error, warn};
 use std::time::Duration;

--- a/consensus/src/backup/saver.rs
+++ b/consensus/src/backup/saver.rs
@@ -1,11 +1,9 @@
 use std::io::Write;
 
-use aleph_bft_types::Terminator;
+use crate::{units::UncheckedSignedUnit, Data, Hasher, Receiver, Sender, Signature, Terminator};
 use codec::Encode;
 use futures::{FutureExt, StreamExt};
 use log::{debug, error};
-
-use crate::{units::UncheckedSignedUnit, Data, Hasher, Receiver, Sender, Signature};
 
 const LOG_TARGET: &str = "AlephBFT-backup-saver";
 
@@ -81,12 +79,11 @@ mod tests {
     };
 
     use aleph_bft_mock::{Data, Hasher64, Keychain, Saver, Signature};
-    use aleph_bft_types::Terminator;
 
     use crate::{
         backup::BackupSaver,
         units::{creator_set, preunit_to_unchecked_signed_unit, UncheckedSignedUnit},
-        NodeCount, NodeIndex,
+        NodeCount, NodeIndex, Terminator,
     };
 
     type TestBackupSaver = BackupSaver<Hasher64, Data, Signature, Saver>;

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -1,4 +1,3 @@
-use aleph_bft_types::{handle_task_termination, Terminator};
 use futures::{
     channel::{mpsc, oneshot},
     future::pending,
@@ -10,9 +9,10 @@ use crate::{
     config::Config,
     creation,
     extender::Extender,
+    handle_task_termination,
     runway::{NotificationIn, NotificationOut},
     terminal::Terminal,
-    Hasher, Receiver, Round, Sender, SpawnHandle,
+    Hasher, Receiver, Round, Sender, SpawnHandle, Terminator,
 };
 
 pub(crate) async fn run<H: Hasher + 'static>(

--- a/consensus/src/creation/mod.rs
+++ b/consensus/src/creation/mod.rs
@@ -2,9 +2,8 @@ use crate::{
     config::{Config as GeneralConfig, DelaySchedule},
     runway::NotificationOut,
     units::{PreUnit, Unit},
-    Hasher, NodeCount, NodeIndex, Receiver, Round, Sender,
+    Hasher, NodeCount, NodeIndex, Receiver, Round, Sender, Terminator,
 };
-use aleph_bft_types::Terminator;
 use futures::{
     channel::{
         mpsc::{SendError, TrySendError},

--- a/consensus/src/extender.rs
+++ b/consensus/src/extender.rs
@@ -1,10 +1,9 @@
 use futures::{FutureExt, StreamExt};
 use std::collections::{HashMap, VecDeque};
 
-use aleph_bft_types::Terminator;
 use log::{debug, warn};
 
-use crate::{Hasher, NodeCount, NodeIndex, NodeMap, Receiver, Round, Sender};
+use crate::{Hasher, NodeCount, NodeIndex, NodeMap, Receiver, Round, Sender, Terminator};
 
 pub(crate) struct ExtenderUnit<H: Hasher> {
     creator: NodeIndex,

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -11,6 +11,7 @@ mod member;
 mod network;
 mod runway;
 mod terminal;
+mod terminator;
 mod units;
 
 mod backup;
@@ -29,6 +30,7 @@ pub use config::{
 };
 pub use member::{run_session, LocalIO};
 pub use network::NetworkData;
+pub use terminator::{handle_task_termination, Terminator};
 
 type Receiver<T> = futures::channel::mpsc::UnboundedReceiver<T>;
 type Sender<T> = futures::channel::mpsc::UnboundedSender<T>;

--- a/consensus/src/member.rs
+++ b/consensus/src/member.rs
@@ -1,4 +1,5 @@
 use crate::{
+    handle_task_termination,
     member::Task::{CoordRequest, ParentsRequest, RequestNewest, UnitBroadcast},
     network,
     runway::{
@@ -8,9 +9,9 @@ use crate::{
     task_queue::TaskQueue,
     units::{UncheckedSignedUnit, UnitCoord},
     Config, Data, DataProvider, FinalizationHandler, Hasher, MultiKeychain, Network, NodeIndex,
-    Receiver, Recipient, Round, Sender, Signature, SpawnHandle, UncheckedSigned,
+    Receiver, Recipient, Round, Sender, Signature, SpawnHandle, Terminator, UncheckedSigned,
 };
-use aleph_bft_types::{handle_task_termination, NodeMap, Terminator};
+use aleph_bft_types::NodeMap;
 use codec::{Decode, Encode};
 use futures::{channel::mpsc, pin_mut, FutureExt, StreamExt};
 use futures_timer::Delay;

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -1,8 +1,7 @@
 use crate::{
     alerts::AlertMessage, member::UnitMessage, Data, Hasher, Network, PartialMultisignature,
-    Receiver, Recipient, Sender, Signature,
+    Receiver, Recipient, Sender, Signature, Terminator,
 };
-use aleph_bft_types::Terminator;
 use codec::{Decode, Encode};
 use futures::{FutureExt, StreamExt};
 use log::{debug, error, warn};

--- a/consensus/src/runway/mod.rs
+++ b/consensus/src/runway/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     alerts::{Alert, ForkProof, ForkingNotification, NetworkMessage},
-    consensus,
+    consensus, handle_task_termination,
     member::UnitMessage,
     units::{
         ControlHash, PreUnit, SignedUnit, UncheckedSignedUnit, Unit, UnitCoord, UnitStore,
@@ -8,9 +8,9 @@ use crate::{
     },
     Config, Data, DataProvider, FinalizationHandler, Hasher, Index, Keychain, MultiKeychain,
     NodeCount, NodeIndex, NodeMap, Receiver, Round, Sender, Signature, Signed, SpawnHandle,
-    UncheckedSigned,
+    Terminator, UncheckedSigned,
 };
-use aleph_bft_types::{handle_task_termination, Recipient, Terminator};
+use aleph_bft_types::Recipient;
 use futures::{
     channel::{mpsc, oneshot},
     pin_mut, Future, FutureExt, StreamExt,

--- a/consensus/src/runway/packer.rs
+++ b/consensus/src/runway/packer.rs
@@ -1,8 +1,8 @@
 use crate::{
     units::{FullUnit, PreUnit, SignedUnit},
     Data, DataProvider, Hasher, MultiKeychain, NodeIndex, Receiver, Sender, SessionId, Signed,
+    Terminator,
 };
-use aleph_bft_types::Terminator;
 use futures::{pin_mut, FutureExt, StreamExt};
 use log::{debug, error};
 use std::marker::PhantomData;
@@ -100,10 +100,10 @@ mod tests {
     use super::Packer;
     use crate::{
         units::{ControlHash, PreUnit, SignedUnit},
-        NodeCount, NodeIndex, Receiver, Sender, SessionId,
+        NodeCount, NodeIndex, Receiver, Sender, SessionId, Terminator,
     };
     use aleph_bft_mock::{Data, DataProvider, Hasher64, Keychain, StalledDataProvider};
-    use aleph_bft_types::{NodeMap, Terminator};
+    use aleph_bft_types::NodeMap;
     use futures::{
         channel::{mpsc, oneshot},
         pin_mut, FutureExt, StreamExt,

--- a/consensus/src/terminal.rs
+++ b/consensus/src/terminal.rs
@@ -8,9 +8,8 @@ use crate::{
     extender::ExtenderUnit,
     runway::{NotificationIn, NotificationOut},
     units::{ControlHash, Unit, UnitCoord},
-    Hasher, NodeCount, NodeIndex, NodeMap, Receiver, Round, Sender,
+    Hasher, NodeCount, NodeIndex, NodeMap, Receiver, Round, Sender, Terminator,
 };
-use aleph_bft_types::Terminator;
 use codec::{Decode, Encode};
 use log::{debug, trace, warn};
 

--- a/consensus/src/terminator.rs
+++ b/consensus/src/terminator.rs
@@ -1,4 +1,3 @@
-use aleph_bft_crypto::NodeIndex;
 use futures::{
     channel::oneshot::{channel, Receiver, Sender},
     future::FusedFuture,
@@ -171,7 +170,7 @@ pub async fn handle_task_termination<T>(
     task_handle: T,
     target: &'static str,
     name: &'static str,
-    index: NodeIndex,
+    index: aleph_bft_types::NodeIndex,
 ) where
     T: FusedFuture<Output = Result<(), ()>>,
 {

--- a/consensus/src/testing/alerts.rs
+++ b/consensus/src/testing/alerts.rs
@@ -2,11 +2,10 @@ use crate::{
     alerts::{Alert, AlertMessage, ForkProof, ForkingNotification, Handler, Service},
     units::{ControlHash, FullUnit, PreUnit},
     Index, Indexed, Keychain as _, NodeCount, NodeIndex, NodeMap, Recipient, Round, Signable,
-    Signed, UncheckedSigned,
+    Signed, Terminator, UncheckedSigned,
 };
 use aleph_bft_mock::{Data, Hasher64, Keychain, PartialMultisignature, Signature};
 use aleph_bft_rmc::Message as RmcMessage;
-use aleph_bft_types::Terminator;
 use futures::{
     channel::{mpsc, oneshot},
     FutureExt, StreamExt,

--- a/consensus/src/testing/consensus.rs
+++ b/consensus/src/testing/consensus.rs
@@ -3,10 +3,9 @@ use crate::{
     runway::{NotificationIn, NotificationOut},
     testing::{complete_oneshot, gen_config, gen_delay_config, init_log},
     units::{ControlHash, PreUnit, Unit, UnitCoord},
-    Hasher, NodeIndex, SpawnHandle,
+    Hasher, NodeIndex, SpawnHandle, Terminator,
 };
 use aleph_bft_mock::{Hasher64, Spawner};
-use aleph_bft_types::Terminator;
 use codec::Encode;
 use futures::{
     channel::{

--- a/consensus/src/testing/creation.rs
+++ b/consensus/src/testing/creation.rs
@@ -3,10 +3,9 @@ use crate::{
     runway::NotificationOut as GenericNotificationOut,
     testing::{gen_config, gen_delay_config},
     units::{FullUnit as GenericFullUnit, PreUnit as GenericPreUnit, Unit as GenericUnit},
-    NodeCount, Receiver, Round, Sender,
+    NodeCount, Receiver, Round, Sender, Terminator,
 };
 use aleph_bft_mock::{Data, Hasher64};
-use aleph_bft_types::Terminator;
 use futures::{
     channel::{mpsc, oneshot},
     FutureExt, StreamExt,

--- a/consensus/src/testing/dag.rs
+++ b/consensus/src/testing/dag.rs
@@ -3,10 +3,9 @@ use crate::{
     runway::{NotificationIn, NotificationOut},
     testing::{complete_oneshot, gen_config, gen_delay_config},
     units::{ControlHash, PreUnit, Unit},
-    NodeCount, NodeIndex, NodeMap, NodeSubset, Receiver, Round, Sender, SpawnHandle,
+    NodeCount, NodeIndex, NodeMap, NodeSubset, Receiver, Round, Sender, SpawnHandle, Terminator,
 };
 use aleph_bft_mock::{Hash64, Hasher64, Spawner};
-use aleph_bft_types::Terminator;
 use futures::{
     channel::{mpsc, oneshot},
     stream::StreamExt,

--- a/consensus/src/testing/mod.rs
+++ b/consensus/src/testing/mod.rs
@@ -10,13 +10,12 @@ mod unreliable;
 
 use crate::{
     create_config, run_session, Config, DelayConfig, LocalIO, Network as NetworkT, NodeCount,
-    NodeIndex, SpawnHandle, TaskHandle,
+    NodeIndex, SpawnHandle, TaskHandle, Terminator,
 };
 use aleph_bft_mock::{
     Data, DataProvider, FinalizationHandler, Hasher64, Keychain, Loader, Network as MockNetwork,
     PartialMultisignature, ReconnectSender as ReconnectSenderGeneric, Saver, Signature, Spawner,
 };
-use aleph_bft_types::Terminator;
 use futures::channel::{mpsc::UnboundedReceiver, oneshot};
 use parking_lot::Mutex;
 use std::{sync::Arc, time::Duration};

--- a/examples/blockchain/Cargo.toml
+++ b/examples/blockchain/Cargo.toml
@@ -9,7 +9,6 @@ publish = false
 [dependencies]
 aleph-bft = { path = "../../consensus", version = "*" }
 aleph-bft-mock = { path = "../../mock", version = "*" }
-aleph-bft-types = { path = "../../types", version = "*" }
 async-trait = "0.1"
 clap = { version = "4", features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "3.0", default-features = false, features = ["derive"] }

--- a/examples/blockchain/src/chain.rs
+++ b/examples/blockchain/src/chain.rs
@@ -1,6 +1,5 @@
 use crate::{network::NetworkData, DataStore};
-use aleph_bft::NodeIndex;
-use aleph_bft_types::Terminator;
+use aleph_bft::{NodeIndex, Terminator};
 use codec::{Decode, Encode};
 use futures::{
     channel::mpsc::{UnboundedReceiver, UnboundedSender},

--- a/examples/blockchain/src/main.rs
+++ b/examples/blockchain/src/main.rs
@@ -10,9 +10,8 @@ use futures::{channel::oneshot, StreamExt};
 use log::{debug, error, info};
 use time::{macros::format_description, OffsetDateTime};
 
-use aleph_bft::{run_session, NodeIndex};
+use aleph_bft::{run_session, NodeIndex, Terminator};
 use aleph_bft_mock::{FinalizationHandler, Keychain, Loader, Saver, Spawner};
-use aleph_bft_types::Terminator;
 use chain::{run_blockchain, Block, BlockNum, ChainConfig};
 use data::{Data, DataProvider, DataStore};
 use network::{Address, NetworkData, NetworkManager};

--- a/examples/blockchain/src/network.rs
+++ b/examples/blockchain/src/network.rs
@@ -1,7 +1,6 @@
 use crate::{Block, Data};
-use aleph_bft::{NodeIndex, Recipient};
+use aleph_bft::{NodeIndex, Recipient, Terminator};
 use aleph_bft_mock::{Hasher64, PartialMultisignature, Signature};
-use aleph_bft_types::Terminator;
 use codec::{Decode, Encode};
 use futures::{
     channel::mpsc::{self, UnboundedReceiver, UnboundedSender},

--- a/examples/ordering/src/main.rs
+++ b/examples/ordering/src/main.rs
@@ -1,9 +1,8 @@
 mod dataio;
 mod network;
 
-use aleph_bft::{run_session, NodeIndex};
+use aleph_bft::{run_session, NodeIndex, Terminator};
 use aleph_bft_mock::{Keychain, Spawner};
-use aleph_bft_types::Terminator;
 use clap::Parser;
 use dataio::{Data, DataProvider, FinalizationHandler};
 use futures::{channel::oneshot, StreamExt};

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,7 +11,6 @@ cargo-fuzz = true
 [dependencies]
 aleph-bft = { path = "../consensus", version = "*" }
 aleph-bft-mock = { path = "../mock", version = "*" }
-aleph-bft-types = { path = "../types", version = "*" }
 async-trait = "0.1"
 codec = { package = "parity-scale-codec", version = "3.0", default-features = false, features = ["derive", "std"] }
 env_logger = "0.10"

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -1,12 +1,11 @@
 use aleph_bft::{
     create_config, run_session, Config, DelayConfig, LocalIO, Network as NetworkT, NetworkData,
-    NodeCount, NodeIndex, Recipient, SpawnHandle, TaskHandle,
+    NodeCount, NodeIndex, Recipient, SpawnHandle, TaskHandle, Terminator,
 };
 use aleph_bft_mock::{
     Data, DataProvider, FinalizationHandler, Hasher64, Keychain, Loader, NetworkHook,
     PartialMultisignature, Router, Saver, Signature,
 };
-use aleph_bft_types::Terminator;
 use codec::{Decode, Encode, IoReader};
 use futures::{
     channel::{oneshot, oneshot::Receiver},

--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -11,7 +11,7 @@ readme = "./README.md"
 description = "Mock implementations of traits required by the aleph-bft package. Do NOT use outside of testing!"
 
 [dependencies]
-aleph-bft-types = { path = "../types", version = "0.10" }
+aleph-bft-types = { path = "../types", version = "0.11" }
 async-trait = "0.1"
 codec = { package = "parity-scale-codec", version = "3.0", default-features = false, features = ["derive"] }
 futures = "0.3"

--- a/rmc/Cargo.toml
+++ b/rmc/Cargo.toml
@@ -14,7 +14,7 @@ description = "Reliable MultiCast - a primitive for Reliable Broadcast protocol.
 
 [dependencies]
 aleph-bft-crypto = { path = "../crypto", version = "0.8" }
-aleph-bft-types = { path = "../types", version = "0.10" }
+aleph-bft-types = { path = "../types", version = "0.11" }
 async-trait = "0.1"
 codec = { package = "parity-scale-codec", version = "3.0", default-features = false, features = ["derive"] }
 futures = "0.3"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-bft-types"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 authors = ["Cardinal Cryptography"]
 documentation = "https://docs.rs/?"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -15,7 +15,3 @@ aleph-bft-crypto = { path = "../crypto", version = "0.8" }
 async-trait = "0.1"
 codec = { package = "parity-scale-codec", version = "3.0", default-features = false, features = ["derive"] }
 futures = "0.3"
-log = "0.4"
-
-[dev-dependencies]
-tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "time"] }

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -3,7 +3,6 @@
 mod dataio;
 mod network;
 mod tasks;
-mod terminator;
 
 pub use aleph_bft_crypto::{
     IncompleteMultisignatureError, Index, Indexed, Keychain, MultiKeychain, Multisigned, NodeCount,
@@ -13,7 +12,6 @@ pub use aleph_bft_crypto::{
 pub use dataio::{DataProvider, FinalizationHandler};
 pub use network::{Network, Recipient};
 pub use tasks::{SpawnHandle, TaskHandle};
-pub use terminator::{handle_task_termination, Terminator};
 
 use codec::Codec;
 use std::{fmt::Debug, hash::Hash as StdHash};


### PR DESCRIPTION
Recently we've moved `Terminator` to `types` as we needed it to be usable by `rmc` in the new shape. Finally tho, we pushed `rmc` in a different shape as initially expected, so `Terminator` doesn't need to be in `types` anymore. 

A better place for terminator is `consensus` as it doesn't exactly fit in `types`, and it being moved to `types` was a sort of a compromise.