### PR TITLE
return the round of a unit with the unit data when the unit is finalized

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-bft"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "aleph-bft-mock",
  "aleph-bft-rmc",
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-bft-mock"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "aleph-bft-types",
  "async-trait",
@@ -132,7 +132,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-bft-types"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "aleph-bft-crypto",
  "async-trait",

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ More details are available [in the book][reference-link-implementation-details].
 - Import AlephBFT in your crate
   ```toml
   [dependencies]
-  aleph-bft = "^0.35"
+  aleph-bft = "^0.36"
   ```
 - The main entry point is the `run_session` function, which returns a Future that runs the
   consensus algorithm.

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-bft"
-version = "0.35.0"
+version = "0.36.0"
 edition = "2021"
 authors = ["Cardinal Cryptography"]
 categories = ["algorithms", "data-structures", "cryptography", "database"]
@@ -14,7 +14,7 @@ description = "AlephBFT is an asynchronous and Byzantine fault tolerant consensu
 
 [dependencies]
 aleph-bft-rmc = { path = "../rmc", version = "0.12" }
-aleph-bft-types = { path = "../types", version = "0.12" }
+aleph-bft-types = { path = "../types", version = "0.13" }
 anyhow = "1.0"
 async-trait = "0.1"
 codec = { package = "parity-scale-codec", version = "3.0", default-features = false, features = ["derive"] }

--- a/consensus/src/runway/mod.rs
+++ b/consensus/src/runway/mod.rs
@@ -649,23 +649,18 @@ where
     }
 
     fn on_ordered_batch(&mut self, batch: Vec<H::Hash>) {
-        let data_iter: Vec<_> = batch
-            .iter()
-            .map(|h| {
-                let unit = self
-                    .store
-                    .unit_by_hash(h)
-                    .expect("Ordered units must be in store")
-                    .as_signable();
+        for hash in batch {
+            let unit = self
+                .store
+                .unit_by_hash(&hash)
+                .expect("Ordered units must be in store")
+                .as_signable();
 
-                (unit.data().clone(), unit.creator())
-            })
-            .collect();
-
-        for (d, creator) in data_iter {
-            if let Some(d) = d {
-                self.finalization_handler.data_finalized(d, creator);
-            }
+            self.finalization_handler.unit_finalized(
+                unit.creator(),
+                unit.round(),
+                unit.data().clone(),
+            )
         }
     }
 

--- a/examples/ordering/src/dataio.rs
+++ b/examples/ordering/src/dataio.rs
@@ -56,7 +56,7 @@ pub struct FinalizationHandler {
 }
 
 impl FinalizationHandlerT<Data> for FinalizationHandler {
-    fn data_finalized(&mut self, d: Data, _creator: NodeIndex) {
+    fn data_finalized(&mut self, d: Data) {
         if let Err(e) = self.tx.unbounded_send(d) {
             error!(target: "finalization-handler", "Error when sending data from FinalizationHandler {:?}.", e);
         }

--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-bft-mock"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 authors = ["Cardinal Cryptography"]
 documentation = "https://docs.rs/?"
@@ -11,7 +11,7 @@ readme = "./README.md"
 description = "Mock implementations of traits required by the aleph-bft package. Do NOT use outside of testing!"
 
 [dependencies]
-aleph-bft-types = { path = "../types", version = "0.12" }
+aleph-bft-types = { path = "../types", version = "0.13" }
 async-trait = "0.1"
 codec = { package = "parity-scale-codec", version = "3.0", default-features = false, features = ["derive"] }
 futures = "0.3"

--- a/mock/src/dataio.rs
+++ b/mock/src/dataio.rs
@@ -1,6 +1,4 @@
-use aleph_bft_types::{
-    DataProvider as DataProviderT, FinalizationHandler as FinalizationHandlerT, NodeIndex,
-};
+use aleph_bft_types::{DataProvider as DataProviderT, FinalizationHandler as FinalizationHandlerT};
 use async_trait::async_trait;
 use codec::{Decode, Encode};
 use futures::{channel::mpsc::unbounded, future::pending, AsyncWrite};
@@ -75,7 +73,7 @@ pub struct FinalizationHandler {
 }
 
 impl FinalizationHandlerT<Data> for FinalizationHandler {
-    fn data_finalized(&mut self, d: Data, _creator: NodeIndex) {
+    fn data_finalized(&mut self, d: Data) {
         if let Err(e) = self.tx.unbounded_send(d) {
             error!(target: "finalization-handler", "Error when sending data from FinalizationHandler {:?}.", e);
         }

--- a/rmc/Cargo.toml
+++ b/rmc/Cargo.toml
@@ -14,7 +14,7 @@ description = "Reliable MultiCast - a primitive for Reliable Broadcast protocol.
 
 [dependencies]
 aleph-bft-crypto = { path = "../crypto", version = "0.9" }
-aleph-bft-types = { path = "../types", version = "0.12" }
+aleph-bft-types = { path = "../types", version = "0.13" }
 async-trait = "0.1"
 codec = { package = "parity-scale-codec", version = "3.0", default-features = false, features = ["derive"] }
 futures = "0.3"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-bft-types"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 authors = ["Cardinal Cryptography"]
 documentation = "https://docs.rs/?"

--- a/types/src/dataio.rs
+++ b/types/src/dataio.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 
 use crate::NodeIndex;
+use crate::Round;
 
 /// The source of data items that consensus should order.
 ///
@@ -21,5 +22,15 @@ pub trait DataProvider<Data>: Sync + Send + 'static {
 pub trait FinalizationHandler<Data>: Sync + Send + 'static {
     /// Data, provided by [DataProvider::get_data], has been finalized.
     /// The calls to this function follow the order of finalization.
-    fn data_finalized(&mut self, data: Data, creator: NodeIndex);
+    fn data_finalized(&mut self, data: Data);
+    /// A unit has been finalized. You can overwrite the default implementation for advanced finalization handling
+    /// in which case the method [`FinalizationHandler::data_finalized`] will not be called anymore if a unit is finalized.
+    /// Please note that this interface is less stable as it exposes intrinsics which migh be subject to change.
+    /// Do not implement this method and only implement [`FinalizationHandler::data_finalized`] unless you
+    /// absolutely know what you are doing.
+    fn unit_finalized(&mut self, _creator: NodeIndex, _round: Round, data: Option<Data>) {
+        if let Some(d) = data {
+            self.data_finalized(d);
+        }
+    }
 }


### PR DESCRIPTION
Fedimint uses Aleph BFT to order a stream of transactions with unpredictable gaps between while ordering a transaction is latency critical. Hence we need to switch sessions before the exponential slowdown starts and can not wait for a fixed number of transactions to achieve consensus on when to trigger the next session switch. Currently nodes submit batches of transactions which may be empty and we trigger a session switch every fixed number of (possibly empty) batches. In a byzantine fault tolerant setting with 3f+1 nodes we can assume that we order at least f batches in every round, however, if all nodes are correct and online we will likely order 3f+1 batches per round, hence we switch the session about three times faster than necessary to prevent running into the exponential slowdown. The times between session switches therefore depend on how many peers are offline / malicious.

If we were to return the round index of an ordered unit with the unit data we can simply trigger the session switch if the round index matches the offset for the exponential slowdown. This gives us more predictable session times, a cleaner way to trigger the session switch and allows us to increase session length by a factor of three without increasing our theoretical bound on RAM consumption per session. Since we opted not to overlay sessions and exchange signatures over the broadcast for simplicity we have a 3x latency spike every session switch - increasing session times 3x this way would therefore by quite useful to us.