### PR TITLE
Allow async implementation for BackupReader and BackupWriter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-bft"
-version = "0.33.1"
+version = "0.34.0"
 dependencies = [
  "aleph-bft-mock",
  "aleph-bft-rmc",
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-bft-mock"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "aleph-bft-types",
  "async-trait",
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-bft-rmc"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "aleph-bft-crypto",
  "aleph-bft-mock",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,7 @@ dependencies = [
  "parking_lot",
  "time",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -1120,6 +1121,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ More details are available [in the book][reference-link-implementation-details].
 - Import AlephBFT in your crate
   ```toml
   [dependencies]
-  aleph-bft = "^0.33"
+  aleph-bft = "^0.34"
   ```
 - The main entry point is the `run_session` function, which returns a Future that runs the
   consensus algorithm.

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-bft"
-version = "0.33.2"
+version = "0.34.0"
 edition = "2021"
 authors = ["Cardinal Cryptography"]
 categories = ["algorithms", "data-structures", "cryptography", "database"]

--- a/consensus/src/backup/loader.rs
+++ b/consensus/src/backup/loader.rs
@@ -1,7 +1,12 @@
-use std::{collections::HashSet, fmt, fmt::Debug, io::Read, marker::PhantomData};
+use std::{
+    collections::HashSet,
+    fmt::{self, Debug},
+    marker::PhantomData,
+    pin::Pin,
+};
 
 use codec::{Decode, Error as CodecError};
-use futures::channel::oneshot;
+use futures::{channel::oneshot, AsyncRead, AsyncReadExt};
 use log::{error, info, warn};
 
 use crate::{
@@ -63,26 +68,26 @@ impl From<CodecError> for LoaderError {
     }
 }
 
-pub struct BackupLoader<H: Hasher, D: Data, S: Signature, R: Read> {
-    backup: R,
+pub struct BackupLoader<H: Hasher, D: Data, S: Signature, R: AsyncRead> {
+    backup: Pin<Box<R>>,
     index: NodeIndex,
     session_id: SessionId,
     _phantom: PhantomData<(H, D, S)>,
 }
 
-impl<H: Hasher, D: Data, S: Signature, R: Read> BackupLoader<H, D, S, R> {
+impl<H: Hasher, D: Data, S: Signature, R: AsyncRead> BackupLoader<H, D, S, R> {
     pub fn new(backup: R, index: NodeIndex, session_id: SessionId) -> BackupLoader<H, D, S, R> {
         BackupLoader {
-            backup,
+            backup: Box::pin(backup),
             index,
             session_id,
             _phantom: PhantomData,
         }
     }
 
-    fn load(&mut self) -> Result<Vec<UncheckedSignedUnit<H, D, S>>, LoaderError> {
+    async fn load(&mut self) -> Result<Vec<UncheckedSignedUnit<H, D, S>>, LoaderError> {
         let mut buf = Vec::new();
-        self.backup.read_to_end(&mut buf)?;
+        self.backup.read_to_end(&mut buf).await?;
         let input = &mut &buf[..];
         let mut result = Vec::new();
         while !input.is_empty() {
@@ -163,7 +168,7 @@ impl<H: Hasher, D: Data, S: Signature, R: Read> BackupLoader<H, D, S, R> {
         starting_round: oneshot::Sender<Option<Round>>,
         next_round_collection: oneshot::Receiver<Round>,
     ) {
-        let units = match self.load() {
+        let units = match self.load().await {
             Ok(items) => items,
             Err(e) => {
                 error!(target: LOG_TARGET, "unable to load backup data: {}", e);

--- a/consensus/src/runway/mod.rs
+++ b/consensus/src/runway/mod.rs
@@ -11,21 +11,15 @@ use crate::{
     Terminator, UncheckedSigned,
 };
 use aleph_bft_types::Recipient;
+use futures::AsyncWrite;
 use futures::{
     channel::{mpsc, oneshot},
-    pin_mut, Future, FutureExt, StreamExt,
+    pin_mut, AsyncRead, Future, FutureExt, StreamExt,
 };
 use futures_timer::Delay;
 use itertools::Itertools;
 use log::{debug, error, info, trace, warn};
-use std::{
-    collections::HashSet,
-    convert::TryFrom,
-    fmt,
-    io::{Read, Write},
-    marker::PhantomData,
-    time::Duration,
-};
+use std::{collections::HashSet, convert::TryFrom, fmt, marker::PhantomData, time::Duration};
 
 mod collection;
 mod packer;
@@ -871,8 +865,8 @@ pub struct RunwayIO<
     H: Hasher,
     D: Data,
     MK: MultiKeychain,
-    W: Write + Send + Sync + 'static,
-    R: Read + Send + Sync + 'static,
+    W: AsyncWrite + Send + Sync + 'static,
+    R: AsyncRead + Send + Sync + 'static,
     DP: DataProvider<D>,
     FH: FinalizationHandler<D>,
 > {
@@ -887,8 +881,8 @@ impl<
         H: Hasher,
         D: Data,
         MK: MultiKeychain,
-        W: Write + Send + Sync + 'static,
-        R: Read + Send + Sync + 'static,
+        W: AsyncWrite + Send + Sync + 'static,
+        R: AsyncRead + Send + Sync + 'static,
         DP: DataProvider<D>,
         FH: FinalizationHandler<D>,
     > RunwayIO<H, D, MK, W, R, DP, FH>
@@ -919,8 +913,8 @@ pub(crate) async fn run<H, D, US, UL, MK, DP, FH, SH>(
 ) where
     H: Hasher,
     D: Data,
-    US: Write + Send + Sync + 'static,
-    UL: Read + Send + Sync + 'static,
+    US: AsyncWrite + Send + Sync + 'static,
+    UL: AsyncRead + Send + Sync + 'static,
     DP: DataProvider<D>,
     FH: FinalizationHandler<D>,
     MK: MultiKeychain,

--- a/examples/ordering/Cargo.toml
+++ b/examples/ordering/Cargo.toml
@@ -18,4 +18,5 @@ futures = "0.3"
 log = "0.4"
 parking_lot = "0.12"
 time = { version = "0.3", features = ["formatting", "macros", "local-offset"] }
-tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "io-util", "net", "time"] }
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "io-util", "net", "time", "fs"] }
+tokio-util = { version = "0.7.10", features = ["compat"] }

--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-bft-mock"
-version = "0.11.1"
+version = "0.12.0"
 edition = "2021"
 authors = ["Cardinal Cryptography"]
 documentation = "https://docs.rs/?"

--- a/rmc/Cargo.toml
+++ b/rmc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-bft-rmc"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 authors = ["Cardinal Cryptography"]
 categories = ["algorithms", "cryptography"]

--- a/rmc/src/handler.rs
+++ b/rmc/src/handler.rs
@@ -1,7 +1,7 @@
 //! Reliable MultiCast - a primitive for Reliable Broadcast protocol.
 pub use aleph_bft_crypto::{
-    Indexed, MultiKeychain, Multisigned, NodeCount, PartialMultisignature, PartiallyMultisigned,
-    Signable, Signature, Signed, UncheckedSigned,
+    Indexed, MultiKeychain, Multisigned, PartialMultisignature, PartiallyMultisigned, Signable,
+    Signed, UncheckedSigned,
 };
 use core::fmt::Debug;
 use std::{

--- a/rmc/src/scheduler.rs
+++ b/rmc/src/scheduler.rs
@@ -1,7 +1,3 @@
-pub use aleph_bft_crypto::{
-    Indexed, MultiKeychain, Multisigned, NodeCount, PartialMultisignature, PartiallyMultisigned,
-    Signable, Signature, Signed, UncheckedSigned,
-};
 use async_trait::async_trait;
 use core::fmt::Debug;
 use futures::future::pending;

--- a/rmc/src/service.rs
+++ b/rmc/src/service.rs
@@ -4,10 +4,7 @@ use crate::{
     scheduler::TaskScheduler,
     Message,
 };
-pub use aleph_bft_crypto::{
-    Indexed, MultiKeychain, Multisigned, NodeCount, PartialMultisignature, PartiallyMultisigned,
-    Signable, Signature, Signed, UncheckedSigned,
-};
+pub use aleph_bft_crypto::{MultiKeychain, Multisigned, Signable};
 use core::fmt::Debug;
 use log::{debug, warn};
 use std::hash::Hash;


### PR DESCRIPTION
using `io::Write` or `io::Read` forces a sync implementation. 

we were using `block_on` to use async inside the implementation, but this blocking the executor and sometimes leads to deadlocks. 

this is backwards compatible by implementing new traits for any `io::Read` and `io::Write` impls.

see https://github.com/fedimint/fedimint/issues/4054 for more context.