### PR TITLE
A0-4006: Check initial unit control hashes early

### DIFF
--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-bft"
-version = "0.33.1"
+version = "0.33.2"
 edition = "2021"
 authors = ["Cardinal Cryptography"]
 categories = ["algorithms", "data-structures", "cryptography", "database"]


### PR DESCRIPTION
Control hashes of initial units have to refer to the empty parent set, so their combined hash is actually known _a priori_ and can be checked early. This also changes one test that used to assume a initial unit with a broken hash can be passed into consensus.

The only connection to A0-4006 is that the test in question failed after the refactor, since I didn't want to react to this incongruous situation internally.