### PR TITLE
Bump rmc version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-bft-rmc"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "aleph-bft-crypto",
  "aleph-bft-mock",

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 description = "AlephBFT is an asynchronous and Byzantine fault tolerant consensus protocol aimed at ordering arbitrary messages (transactions). It has been designed to continuously operate even in the harshest conditions: with no bounds on message-delivery delays and in the presence of malicious actors. This makes it an excellent fit for blockchain-related applications."
 
 [dependencies]
-aleph-bft-rmc = { path = "../rmc", version = "0.12" }
+aleph-bft-rmc = { path = "../rmc", version = "0.13" }
 aleph-bft-types = { path = "../types", version = "0.13" }
 anyhow = "1.0"
 async-trait = "0.1"

--- a/rmc/Cargo.toml
+++ b/rmc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-bft-rmc"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 authors = ["Cardinal Cryptography"]
 categories = ["algorithms", "cryptography"]


### PR DESCRIPTION
This was missed in one earlier PR and caused version pushes to not work for a while. They failed silently so it took a moment to nitice. Due to new versions not being pushed I'm not bumping the consensus version, despite the deps changing.