### PR TITLE
Create BackupWriter and BackupReader traits for async unit backup

### DIFF
--- a/consensus/src/member.rs
+++ b/consensus/src/member.rs
@@ -13,12 +13,13 @@ use crate::{
 };
 use aleph_bft_types::NodeMap;
 use codec::{Decode, Encode};
-use futures::{channel::mpsc, pin_mut, AsyncRead, AsyncWrite, FutureExt, StreamExt};
+use futures::{channel::mpsc, pin_mut, FutureExt, StreamExt};
 use futures_timer::Delay;
 use itertools::Itertools;
 use log::{debug, error, info, trace, warn};
 use network::NetworkData;
 use rand::{prelude::SliceRandom, Rng};
+use aleph_bft_types::BackupWriter;
 use std::{
     collections::HashSet,
     convert::TryInto,
@@ -26,6 +27,8 @@ use std::{
     marker::PhantomData,
     time::Duration,
 };
+use aleph_bft_types::BackupReader;
+
 
 /// A message concerning units, either about new units or some requests for them.
 #[derive(Clone, Eq, PartialEq, Debug, Decode, Encode)]
@@ -111,8 +114,8 @@ pub struct LocalIO<
     D: Data,
     DP: DataProvider<D>,
     FH: FinalizationHandler<D>,
-    US: AsyncWrite,
-    UL: AsyncRead,
+    US: BackupWriter,
+    UL: BackupReader,
 > {
     data_provider: DP,
     finalization_handler: FH,
@@ -121,7 +124,7 @@ pub struct LocalIO<
     _phantom: PhantomData<D>,
 }
 
-impl<D: Data, DP: DataProvider<D>, FH: FinalizationHandler<D>, US: AsyncWrite, UL: AsyncRead>
+impl<D: Data, DP: DataProvider<D>, FH: FinalizationHandler<D>, US: BackupWriter, UL: BackupReader>
     LocalIO<D, DP, FH, US, UL>
 {
     pub fn new(
@@ -578,8 +581,8 @@ pub async fn run_session<
     D: Data,
     DP: DataProvider<D>,
     FH: FinalizationHandler<D>,
-    US: AsyncWrite + Send + Sync + 'static,
-    UL: AsyncRead + Send + Sync + 'static,
+    US: BackupWriter + Send + Sync + 'static,
+    UL: BackupReader + Send + Sync + 'static,
     N: Network<NetworkData<H, D, MK::Signature, MK::PartialMultisignature>> + 'static,
     SH: SpawnHandle,
     MK: MultiKeychain,

--- a/consensus/src/runway/mod.rs
+++ b/consensus/src/runway/mod.rs
@@ -14,11 +14,13 @@ use crate::{
     UncheckedSigned,
 };
 use aleph_bft_types::Recipient;
+use aleph_bft_types::BackupReader;
 use futures::{
     channel::{mpsc, oneshot},
     future::pending,
-    pin_mut, AsyncRead, AsyncWrite, Future, FutureExt, StreamExt,
+    pin_mut, Future, FutureExt, StreamExt,
 };
+use aleph_bft_types::BackupWriter;
 use futures_timer::Delay;
 use itertools::Itertools;
 use log::{debug, error, info, trace, warn};
@@ -667,8 +669,8 @@ pub struct RunwayIO<
     H: Hasher,
     D: Data,
     MK: MultiKeychain,
-    W: AsyncWrite + Send + Sync + 'static,
-    R: AsyncRead + Send + Sync + 'static,
+    W: BackupWriter + Send + Sync + 'static,
+    R: BackupReader + Send + Sync + 'static,
     DP: DataProvider<D>,
     FH: FinalizationHandler<D>,
 > {
@@ -683,8 +685,8 @@ impl<
         H: Hasher,
         D: Data,
         MK: MultiKeychain,
-        W: AsyncWrite + Send + Sync + 'static,
-        R: AsyncRead + Send + Sync + 'static,
+        W: BackupWriter + Send + Sync + 'static,
+        R: BackupReader + Send + Sync + 'static,
         DP: DataProvider<D>,
         FH: FinalizationHandler<D>,
     > RunwayIO<H, D, MK, W, R, DP, FH>
@@ -715,8 +717,8 @@ pub(crate) async fn run<H, D, US, UL, MK, DP, FH, SH>(
 ) where
     H: Hasher,
     D: Data,
-    US: AsyncWrite + Send + Sync + 'static,
-    UL: AsyncRead + Send + Sync + 'static,
+    US: BackupWriter + Send + Sync + 'static,
+    UL: BackupReader + Send + Sync + 'static,
     DP: DataProvider<D>,
     FH: FinalizationHandler<D>,
     MK: MultiKeychain,

--- a/types/src/backup.rs
+++ b/types/src/backup.rs
@@ -1,0 +1,37 @@
+use async_trait::async_trait;
+use std::marker::Unpin;
+use futures::io::{AsyncRead, AsyncWrite};
+use futures::{AsyncReadExt, AsyncWriteExt};
+
+
+
+#[async_trait]
+/// Write backups to peristent storage.
+pub trait BackupWriter {
+    /// Append new data to the backup.
+    async fn append(&mut self, data: &[u8]) -> std::io::Result<()>;
+}
+
+#[async_trait]
+impl<W: AsyncWrite + Send + Unpin> BackupWriter for W {
+    async fn append(&mut self, data: &[u8]) -> std::io::Result<()> {
+        self.write_all(data).await?;
+        self.flush().await
+    }
+}
+
+
+#[async_trait]
+pub trait BackupReader {
+    /// Read the entire backup.
+    async fn read(&mut self) -> std::io::Result<Vec<u8>>;
+}
+
+#[async_trait]
+impl<R: AsyncRead + Send + Unpin> BackupReader for R {
+    async fn read(&mut self) -> std::io::Result<Vec<u8>> {
+        let mut buf = Vec::new();
+        self.read_to_end(&mut buf).await?;
+        Ok(buf)
+    }
+}

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -3,6 +3,7 @@
 mod dataio;
 mod network;
 mod tasks;
+mod backup;
 
 pub use aleph_bft_crypto::{
     IncompleteMultisignatureError, Index, Indexed, Keychain, MultiKeychain, Multisigned, NodeCount,
@@ -12,6 +13,7 @@ pub use aleph_bft_crypto::{
 pub use dataio::{DataProvider, FinalizationHandler};
 pub use network::{Network, Recipient};
 pub use tasks::{SpawnHandle, TaskHandle};
+pub use backup::{BackupReader, BackupWriter};
 
 use codec::Codec;
 use std::{fmt::Debug, hash::Hash as StdHash};


### PR DESCRIPTION
This pr is reproposing the original design in https://github.com/Cardinal-Cryptography/AlephBFT/pull/399 before it was switched to using AsyncRead and AsyncWrite. The initial design proposed here is currently implemented in our fork and allows a very clean integration with our async database abstraction over RocksDB. Please find the integration into Fedimint here https://github.com/fedimint/fedimint/blob/master/fedimint-server/src/atomic_broadcast/backup.rs

The current API using AsyncWrite is quite low level and therefore quite unpractical for us, however I did not notice at the time that the api design in the original pr was changed otherwise I would have brought it up at the time. My apologies for the unnecessary back and forth this caused you; I should have caught this at the time.

I am reopening the issue now as we intend to switch from our fork back to upstream. 

Please note that reading the backup was never really the issue and I am proposing it with two traits here for symmetry which makes it a little cleaner imo. We could therefore also stick to AsyncRead instead of defining a new trait or just take a byte vector / boxed slice directly since we are reading it all into a vector at once anyway.

I am aware that there were concerns around introducing new traits for this, however, after implementing both sides integrating via these traits it seems to me that this interface is the cleanest on both sides so it seems worth it.