### PR TITLE
A0-4341: Bump some versions that caused autopublishing to fail

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-bft"
-version = "0.37.2"
+version = "0.38.0"
 dependencies = [
  "aleph-bft-mock",
  "aleph-bft-rmc",
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-bft-rmc"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "aleph-bft-crypto",
  "aleph-bft-mock",

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ More details are available [in the book][reference-link-implementation-details].
 - Import AlephBFT in your crate
   ```toml
   [dependencies]
-  aleph-bft = "^0.37"
+  aleph-bft = "^0.38"
   ```
 - The main entry point is the `run_session` function, which returns a Future that runs the
   consensus algorithm.

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-bft"
-version = "0.37.3"
+version = "0.38.0"
 edition = "2021"
 authors = ["Cardinal Cryptography"]
 categories = ["algorithms", "data-structures", "cryptography", "database"]
@@ -13,7 +13,7 @@ readme = "../README.md"
 description = "AlephBFT is an asynchronous and Byzantine fault tolerant consensus protocol aimed at ordering arbitrary messages (transactions). It has been designed to continuously operate even in the harshest conditions: with no bounds on message-delivery delays and in the presence of malicious actors. This makes it an excellent fit for blockchain-related applications."
 
 [dependencies]
-aleph-bft-rmc = { path = "../rmc", version = "0.13" }
+aleph-bft-rmc = { path = "../rmc", version = "0.14" }
 aleph-bft-types = { path = "../types", version = "0.14" }
 anyhow = "1.0"
 async-trait = "0.1"

--- a/rmc/Cargo.toml
+++ b/rmc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-bft-rmc"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 authors = ["Cardinal Cryptography"]
 categories = ["algorithms", "cryptography"]


### PR DESCRIPTION
By the way, failures in the publishing workflow don't show up as failures in pipelines, only in some "annotations", very annoying. :<