### PR TITLE
A0-4563: Added unit test for censorship resistance in Extender

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-bft"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "aleph-bft-mock",
  "aleph-bft-rmc",

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-bft"
-version = "0.39.0"
+version = "0.39.1"
 edition = "2021"
 authors = ["Cardinal Cryptography"]
 categories = ["algorithms", "data-structures", "cryptography", "database"]

--- a/consensus/src/dag/mod.rs
+++ b/consensus/src/dag/mod.rs
@@ -468,7 +468,7 @@ mod test {
             .take(5)
             .cloned()
             .collect();
-        let fork = random_unit_with_parents(forker_id, &fork_parents);
+        let fork = random_unit_with_parents(forker_id, &fork_parents, 3);
         let fork = Signed::sign(fork, &keychains[forker_id.0]);
         let unit = units
             .get(3)
@@ -552,7 +552,7 @@ mod test {
             .take(5)
             .cloned()
             .collect();
-        let fork = random_unit_with_parents(forker_id, &fork_parents);
+        let fork = random_unit_with_parents(forker_id, &fork_parents, 3);
         let fork = Signed::sign(fork, &keychains[forker_id.0]);
         let unit = units
             .get(3)

--- a/consensus/src/extension/election.rs
+++ b/consensus/src/extension/election.rs
@@ -217,9 +217,8 @@ mod test {
             units::Units,
         },
         units::{
-            random_full_parent_reconstrusted_units_up_to, random_reconstructed_unit_with_parents,
-            minimal_reconstructed_dag_units_up_to,
-            TestingDagUnit, Unit,
+            minimal_reconstructed_dag_units_up_to, random_full_parent_reconstrusted_units_up_to,
+            random_reconstructed_unit_with_parents, TestingDagUnit, Unit,
         },
         NodeCount,
     };
@@ -345,7 +344,7 @@ mod test {
                     creator,
                     &parents,
                     &keychains[creator.0],
-                    round
+                    round,
                 ));
             }
         }
@@ -369,7 +368,8 @@ mod test {
         let session_id = 2137;
         let keychains = Keychain::new_vec(n_members);
 
-        let (dag, inactive_node_first_unit) = minimal_reconstructed_dag_units_up_to( max_round, n_members, session_id, &keychains);
+        let (dag, inactive_node_first_unit) =
+            minimal_reconstructed_dag_units_up_to(max_round, n_members, session_id, &keychains);
         for round in dag {
             for unit in round {
                 units.add_unit(unit);

--- a/consensus/src/extension/election.rs
+++ b/consensus/src/extension/election.rs
@@ -345,6 +345,7 @@ mod test {
                     creator,
                     &parents,
                     &keychains[creator.0],
+                    round
                 ));
             }
         }
@@ -359,6 +360,7 @@ mod test {
     }
 
     #[test]
+    #[ignore]
     fn given_minimal_dag_with_orphaned_node_when_electing_then_orphaned_node_is_not_head() {
         use ElectionResult::*;
         let mut units = Units::new();
@@ -370,7 +372,6 @@ mod test {
         let (dag, inactive_node_first_unit) = minimal_reconstructed_dag_units_up_to( max_round, n_members, session_id, &keychains);
         for round in dag {
             for unit in round {
-                println!("{:?}", &unit);
                 units.add_unit(unit);
             }
         }
@@ -379,7 +380,6 @@ mod test {
             Pending(_) => panic!("should have elected"),
             Elected(head) => {
                 // This should be the second unit in order, as the first was not popular.
-                println!("{:?}", &head);
                 assert_ne!(head, inactive_node_first_unit.hash());
             }
         }

--- a/consensus/src/extension/election.rs
+++ b/consensus/src/extension/election.rs
@@ -218,6 +218,7 @@ mod test {
         },
         units::{
             random_full_parent_reconstrusted_units_up_to, random_reconstructed_unit_with_parents,
+            minimal_reconstructed_dag_units_up_to,
             TestingDagUnit, Unit,
         },
         NodeCount,
@@ -353,6 +354,33 @@ mod test {
             Elected(head) => {
                 // This should be the second unit in order, as the first was not popular.
                 assert_eq!(head, candidate_hashes[1]);
+            }
+        }
+    }
+
+    #[test]
+    fn given_minimal_dag_with_orphaned_node_when_electing_then_orphaned_node_is_not_head() {
+        use ElectionResult::*;
+        let mut units = Units::new();
+        let n_members = NodeCount(14);
+        let max_round = 4;
+        let session_id = 2137;
+        let keychains = Keychain::new_vec(n_members);
+
+        let (dag, inactive_node_first_unit) = minimal_reconstructed_dag_units_up_to( max_round, n_members, session_id, &keychains);
+        for round in dag {
+            for unit in round {
+                println!("{:?}", &unit);
+                units.add_unit(unit);
+            }
+        }
+        let election = RoundElection::for_round(0, &units).expect("we have enough rounds");
+        match election {
+            Pending(_) => panic!("should have elected"),
+            Elected(head) => {
+                // This should be the second unit in order, as the first was not popular.
+                println!("{:?}", &head);
+                assert_ne!(head, inactive_node_first_unit.hash());
             }
         }
     }

--- a/consensus/src/extension/election.rs
+++ b/consensus/src/extension/election.rs
@@ -360,6 +360,7 @@ mod test {
 
     #[test]
     #[ignore]
+    // TODO(A0-4563) Uncomment after changes to parent voting code
     fn given_minimal_dag_with_orphaned_node_when_electing_then_orphaned_node_is_not_head() {
         use ElectionResult::*;
         let mut units = Units::new();

--- a/consensus/src/extension/extender.rs
+++ b/consensus/src/extension/extender.rs
@@ -101,6 +101,7 @@ mod test {
 
     #[test]
     #[ignore]
+    // TODO(A0-4563) Uncomment after changes to parent voting code
     fn given_minimal_dag_with_orphaned_node_when_producing_batches_have_correct_length() {
         let mut extender = Extender::new();
         let n_members = NodeCount(4);

--- a/consensus/src/extension/extender.rs
+++ b/consensus/src/extension/extender.rs
@@ -100,11 +100,12 @@ mod test {
     }
 
     #[test]
+    #[ignore]
     fn given_minimal_dag_with_orphaned_node_when_producing_batches_have_correct_length() {
         let mut extender = Extender::new();
-        let n_members = NodeCount(14);
+        let n_members = NodeCount(4);
         let threshold = n_members.consensus_threshold();
-        let max_round: Round = 79;
+        let max_round: Round = 4;
         let session_id = 2137;
         let keychains = Keychain::new_vec(n_members);
         let mut batches = Vec::new();
@@ -117,10 +118,8 @@ mod test {
         assert_eq!(batches.len(), (max_round - 3).into());
         assert_eq!(batches[0].len(), 1);
         assert_eq!(batches[0][0].round(), 0);
-        for (round, batch) in batches.iter().skip(1).enumerate() {
+        for batch in batches.iter().skip(1) {
             assert_eq!(batch.len(), threshold.0);
-            assert_eq!(batch.last().unwrap().round(), round as Round + 1);
-            assert!(batch.iter().rev().skip(1).all(|unit| unit.round() == round as Round));
         }
     }
 }

--- a/consensus/src/extension/extender.rs
+++ b/consensus/src/extension/extender.rs
@@ -70,12 +70,12 @@ impl<U: UnitWithParents> Extender<U> {
 
 #[cfg(test)]
 mod test {
+    use crate::units::{minimal_reconstructed_dag_units_up_to, Unit};
     use crate::{
         extension::extender::Extender, units::random_full_parent_reconstrusted_units_up_to,
         NodeCount, Round,
     };
     use aleph_bft_mock::Keychain;
-    use crate::units::{minimal_reconstructed_dag_units_up_to, Unit};
 
     #[test]
     fn easy_elections() {
@@ -109,7 +109,8 @@ mod test {
         let session_id = 2137;
         let keychains = Keychain::new_vec(n_members);
         let mut batches = Vec::new();
-        let (dag, _) = minimal_reconstructed_dag_units_up_to( max_round, n_members, session_id, &keychains);
+        let (dag, _) =
+            minimal_reconstructed_dag_units_up_to(max_round, n_members, session_id, &keychains);
         for round in dag {
             for unit in round {
                 batches.append(&mut extender.add_unit(unit));

--- a/consensus/src/units/mod.rs
+++ b/consensus/src/units/mod.rs
@@ -15,11 +15,12 @@ mod validator;
 pub(crate) use store::*;
 #[cfg(test)]
 pub use testing::{
-    create_preunits, creator_set, full_unit_to_unchecked_signed_unit, preunit_to_full_unit,
-    preunit_to_signed_unit, preunit_to_unchecked_signed_unit, minimal_reconstructed_dag_units_up_to,
-    random_full_parent_reconstrusted_units_up_to, random_full_parent_units_up_to,
-    random_reconstructed_unit_with_parents, random_unit_with_parents, DagUnit as TestingDagUnit,
-    FullUnit as TestingFullUnit, SignedUnit as TestingSignedUnit, WrappedSignedUnit,
+    create_preunits, creator_set, full_unit_to_unchecked_signed_unit,
+    minimal_reconstructed_dag_units_up_to, preunit_to_full_unit, preunit_to_signed_unit,
+    preunit_to_unchecked_signed_unit, random_full_parent_reconstrusted_units_up_to,
+    random_full_parent_units_up_to, random_reconstructed_unit_with_parents,
+    random_unit_with_parents, DagUnit as TestingDagUnit, FullUnit as TestingFullUnit,
+    SignedUnit as TestingSignedUnit, WrappedSignedUnit,
 };
 pub use validator::{ValidationError, Validator};
 

--- a/consensus/src/units/mod.rs
+++ b/consensus/src/units/mod.rs
@@ -16,7 +16,7 @@ pub(crate) use store::*;
 #[cfg(test)]
 pub use testing::{
     create_preunits, creator_set, full_unit_to_unchecked_signed_unit, preunit_to_full_unit,
-    preunit_to_signed_unit, preunit_to_unchecked_signed_unit,
+    preunit_to_signed_unit, preunit_to_unchecked_signed_unit, minimal_reconstructed_dag_units_up_to,
     random_full_parent_reconstrusted_units_up_to, random_full_parent_units_up_to,
     random_reconstructed_unit_with_parents, random_unit_with_parents, DagUnit as TestingDagUnit,
     FullUnit as TestingFullUnit, SignedUnit as TestingSignedUnit, WrappedSignedUnit,

--- a/consensus/src/units/testing.rs
+++ b/consensus/src/units/testing.rs
@@ -1,4 +1,4 @@
-use rand::prelude::{IteratorRandom};
+use crate::units::TestingDagUnit;
 use crate::{
     creation::Creator as GenericCreator,
     dag::ReconstructedUnit,
@@ -10,7 +10,7 @@ use crate::{
     NodeCount, NodeIndex, NodeMap, Round, SessionId, Signed,
 };
 use aleph_bft_mock::{Data, Hash64, Hasher64, Keychain, Signature};
-use crate::units::{TestingDagUnit};
+use rand::prelude::IteratorRandom;
 
 type ControlHash = GenericControlHash<Hasher64>;
 type Creator = GenericCreator<Hasher64>;
@@ -210,7 +210,7 @@ pub fn random_full_parent_reconstrusted_units_up_to(
                     node_id,
                     result.last().expect("previous round present"),
                     &keychains[node_id.0],
-                    r
+                    r,
                 )
             })
             .collect();
@@ -233,11 +233,17 @@ pub fn minimal_reconstructed_dag_units_up_to(
     let mut dag = vec![random_initial_reconstructed_units(
         n_members, session_id, keychains,
     )];
-    let inactive_node_first_and_last_seen_unit = dag.last().expect("previous round present")
-        .last().expect("there is at least one node").clone();
-    let inactive_node = inactive_node_first_and_last_seen_unit.creator();  
+    let inactive_node_first_and_last_seen_unit = dag
+        .last()
+        .expect("previous round present")
+        .last()
+        .expect("there is at least one node")
+        .clone();
+    let inactive_node = inactive_node_first_and_last_seen_unit.creator();
     for r in 1..=round {
-        let mut parents: Vec<TestingDagUnit> = dag.last().expect("previous round present")
+        let mut parents: Vec<TestingDagUnit> = dag
+            .last()
+            .expect("previous round present")
             .clone()
             .into_iter()
             .filter(|unit| unit.creator() != inactive_node)
@@ -245,7 +251,8 @@ pub fn minimal_reconstructed_dag_units_up_to(
             .into_iter()
             .collect();
         if r == round {
-            let ancestor_unit = dag.get(r as usize - 4)
+            let ancestor_unit = dag
+                .get(r as usize - 4)
                 .expect("ancestor round present")
                 .get(inactive_node.0)
                 .expect("inactive node unit present");
@@ -255,12 +262,7 @@ pub fn minimal_reconstructed_dag_units_up_to(
             .into_iterator()
             .filter(|node_id| node_id != &inactive_node)
             .map(|node_id| {
-                random_reconstructed_unit_with_parents(
-                    node_id,
-                    &parents,
-                    &keychains[node_id.0],
-                    r
-                )
+                random_reconstructed_unit_with_parents(node_id, &parents, &keychains[node_id.0], r)
             })
             .collect();
         dag.push(units);

--- a/consensus/src/units/testing.rs
+++ b/consensus/src/units/testing.rs
@@ -252,8 +252,8 @@ pub fn minimal_reconstructed_dag_units_up_to(
             .collect();
         if r == round {
             let ancestor_unit = dag
-                .get(r as usize - 4)
-                .expect("ancestor round present")
+                .get(0)
+                .expect("first round present")
                 .get(inactive_node.0)
                 .expect("inactive node unit present");
             parents.push(ancestor_unit.clone());

--- a/consensus/src/units/testing.rs
+++ b/consensus/src/units/testing.rs
@@ -252,7 +252,7 @@ pub fn minimal_reconstructed_dag_units_up_to(
             .collect();
         if r == round {
             let ancestor_unit = dag
-                .get(0)
+                .first()
                 .expect("first round present")
                 .get(inactive_node.0)
                 .expect("inactive node unit present");

--- a/consensus/src/units/validator.rs
+++ b/consensus/src/units/validator.rs
@@ -254,7 +254,7 @@ mod tests {
             .take(4)
             .cloned()
             .collect();
-        let unit = random_unit_with_parents(creator_id, &parents);
+        let unit = random_unit_with_parents(creator_id, &parents, 1);
         let preunit = unit.as_pre_unit().clone();
         let keychain = Keychain::new(n_members, creator_id);
         let unchecked_unit = full_unit_to_unchecked_signed_unit(unit, &keychain);


### PR DESCRIPTION
Introduced 2 UTs, similar to existing ones, but with prepared DAG that contains non-direct parents. It turns out that current testing code almost support non-direct parents, as `ReconstructedUnit` control hash is created based on the parents injected by the test, except one method `random_unit_with_parents` that assumed each parent round is the same. 

Currently, those tests are disabled since they (expectedly) panic at 
```
units are added in order
thread 'extension::extender::test::given_minimal_dag_with_orphaned_node_when_producing_batches_have_correct_length' panicked at consensus/src/extension/election.rs:56:42:
```

This PR should not contain any changes to the production code.