### PR TITLE
A0-4563: Introduce notion of non-direct parents in Extender

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -20,6 +20,11 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v4
 
+      - name: Install cargo audit
+        shell: bash
+        run: |
+          cargo install cargo-audit --locked
+
       - name: Run `cargo-audit`
         uses: actions-rs/audit-check@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-bft"
-version = "0.39.1"
+version = "0.40.0"
 dependencies = [
  "aleph-bft-mock",
  "aleph-bft-rmc",

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ More details are available [in the book][reference-link-implementation-details].
 - Import AlephBFT in your crate
   ```toml
   [dependencies]
-  aleph-bft = "^0.39"
+  aleph-bft = "^0.40"
   ```
 - The main entry point is the `run_session` function, which returns a Future that runs the
   consensus algorithm.

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-bft"
-version = "0.39.1"
+version = "0.40.0"
 edition = "2021"
 authors = ["Cardinal Cryptography"]
 categories = ["algorithms", "data-structures", "cryptography", "database"]

--- a/consensus/src/dag/reconstruction/dag.rs
+++ b/consensus/src/dag/reconstruction/dag.rs
@@ -96,7 +96,6 @@ impl<U: UnitWithParents> Dag<U> {
         }
         let missing_parents = unit
             .parents()
-            .values()
             .filter(|parent| !self.dag_units.contains(parent))
             .cloned()
             .collect();

--- a/consensus/src/dag/reconstruction/mod.rs
+++ b/consensus/src/dag/reconstruction/mod.rs
@@ -93,7 +93,7 @@ impl<U: Unit> UnitWithParents for ReconstructedUnit<U> {
             .filter_map(|(hash, parent_round)| match self.unit.coord().round() {
                 // round 0 units cannot have non-empty parents
                 0 => None,
-                
+
                 unit_round => {
                     if unit_round - 1 == *parent_round {
                         Some(hash)

--- a/consensus/src/dag/reconstruction/mod.rs
+++ b/consensus/src/dag/reconstruction/mod.rs
@@ -29,7 +29,8 @@ impl<U: Unit> ReconstructedUnit<U> {
                 let unit_round = unit.round();
                 let mut parents_with_rounds = NodeMap::with_size(parents.size());
                 for (parent_index, hash) in parents.into_iter() {
-                    parents_with_rounds.insert(parent_index, (hash, unit_round - 1));
+                    // we cannot have here round 0 units
+                    parents_with_rounds.insert(parent_index, (hash, unit_round.saturating_sub(1)));
                 }
                 Ok(ReconstructedUnit {
                     unit,
@@ -90,7 +91,9 @@ impl<U: Unit> UnitWithParents for ReconstructedUnit<U> {
         self.parents
             .values()
             .filter_map(|(hash, parent_round)| match self.unit.coord().round() {
+                // round 0 units cannot have non-empty parents
                 0 => None,
+                
                 unit_round => {
                     if unit_round - 1 == *parent_round {
                         Some(hash)
@@ -105,7 +108,7 @@ impl<U: Unit> UnitWithParents for ReconstructedUnit<U> {
         self.parents.get(index).map(|(hash, _)| hash)
     }
 
-    fn parents_size(&self) -> NodeCount {
+    fn node_count(&self) -> NodeCount {
         self.parents.size()
     }
 }

--- a/consensus/src/dag/reconstruction/mod.rs
+++ b/consensus/src/dag/reconstruction/mod.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-
+use aleph_bft_rmc::NodeCount;
 use crate::{
     units::{ControlHash, FullUnit, HashFor, Unit, UnitCoord, UnitWithParents, WrappedUnit},
     Hasher, NodeMap, SessionId,
@@ -8,7 +8,7 @@ use crate::{
 mod dag;
 mod parents;
 
-use aleph_bft_types::{Data, MultiKeychain, OrderedUnit, Signed};
+use aleph_bft_types::{Data, MultiKeychain, NodeIndex, OrderedUnit, Round, Signed};
 use dag::Dag;
 use parents::Reconstruction as ParentReconstruction;
 
@@ -16,7 +16,7 @@ use parents::Reconstruction as ParentReconstruction;
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct ReconstructedUnit<U: Unit> {
     unit: U,
-    parents: NodeMap<HashFor<U>>,
+    parents: NodeMap<(HashFor<U>, Round)>,
 }
 
 impl<U: Unit> ReconstructedUnit<U> {
@@ -25,7 +25,17 @@ impl<U: Unit> ReconstructedUnit<U> {
         match unit.control_hash().combined_hash
             == ControlHash::<U::Hasher>::combine_hashes(&parents)
         {
-            true => Ok(ReconstructedUnit { unit, parents }),
+            true => {
+                let unit_round = unit.round();
+                let mut parents_with_rounds =  NodeMap::with_size(parents.size());
+                for (parent_index, hash) in parents.into_iter() {
+                    parents_with_rounds.insert(parent_index, (hash, unit_round - 1));
+                }
+                Ok(ReconstructedUnit {
+                unit,
+                parents: parents_with_rounds,
+                })
+            },
             false => Err(unit),
         }
     }
@@ -72,8 +82,25 @@ impl<U: Unit> WrappedUnit<U::Hasher> for ReconstructedUnit<U> {
 }
 
 impl<U: Unit> UnitWithParents for ReconstructedUnit<U> {
-    fn parents(&self) -> &NodeMap<HashFor<Self>> {
-        &self.parents
+    fn parents(&self) -> impl Iterator<Item = &HashFor<U>> {
+        self.parents.values().map(|(hash, _)| hash)
+    }
+
+    fn direct_parents(&self) -> impl Iterator<Item = &HashFor<Self>> {
+        self.parents.values().filter_map(|(hash, parent_round)| {
+            match self.unit.coord().round() {
+                0 => None,
+                unit_round => if unit_round - 1 == *parent_round { Some(hash) } else { None },
+            }
+        })
+    }
+
+    fn parent_for(&self, index: NodeIndex) -> Option<&HashFor<Self>> {
+        self.parents.get(index).map(|(hash, _)| hash)
+    }
+
+    fn parents_size(&self) -> NodeCount {
+        self.parents.size()
     }
 }
 
@@ -89,7 +116,7 @@ impl<D: Data, H: Hasher, K: MultiKeychain> From<ReconstructedUnit<Signed<FullUni
     for OrderedUnit<D, H>
 {
     fn from(unit: ReconstructedUnit<Signed<FullUnit<H, D>, K>>) -> Self {
-        let parents = unit.parents().values().cloned().collect();
+        let parents = unit.parents().cloned().collect();
         let unit = unit.unpack();
         let creator = unit.creator();
         let round = unit.round();
@@ -233,7 +260,7 @@ mod test {
             assert_eq!(units.len(), 1);
             let reconstructed_unit = units.pop().expect("just checked its there");
             assert_eq!(reconstructed_unit, ReconstructedUnit::initial(unit.clone()));
-            assert_eq!(reconstructed_unit.parents().item_count(), 0);
+            assert_eq!(reconstructed_unit.parents().count(), 0);
         }
     }
 
@@ -254,15 +281,15 @@ mod test {
                 match round {
                     0 => {
                         assert_eq!(reconstructed_unit, ReconstructedUnit::initial(unit.clone()));
-                        assert_eq!(reconstructed_unit.parents().item_count(), 0);
+                        assert_eq!(reconstructed_unit.parents().count(), 0);
                     }
                     round => {
-                        assert_eq!(reconstructed_unit.parents().item_count(), 4);
+                        assert_eq!(reconstructed_unit.parents().count(), 4);
                         let parents = dag
                             .get((round - 1) as usize)
                             .expect("the parents are there");
                         for (parent, reconstructed_parent) in
-                            parents.iter().zip(reconstructed_unit.parents().values())
+                            parents.iter().zip(reconstructed_unit.parents())
                         {
                             assert_eq!(&parent.hash(), reconstructed_parent);
                         }

--- a/consensus/src/dag/reconstruction/mod.rs
+++ b/consensus/src/dag/reconstruction/mod.rs
@@ -1,9 +1,9 @@
-use std::collections::HashMap;
-use aleph_bft_rmc::NodeCount;
 use crate::{
     units::{ControlHash, FullUnit, HashFor, Unit, UnitCoord, UnitWithParents, WrappedUnit},
     Hasher, NodeMap, SessionId,
 };
+use aleph_bft_rmc::NodeCount;
+use std::collections::HashMap;
 
 mod dag;
 mod parents;
@@ -27,15 +27,15 @@ impl<U: Unit> ReconstructedUnit<U> {
         {
             true => {
                 let unit_round = unit.round();
-                let mut parents_with_rounds =  NodeMap::with_size(parents.size());
+                let mut parents_with_rounds = NodeMap::with_size(parents.size());
                 for (parent_index, hash) in parents.into_iter() {
                     parents_with_rounds.insert(parent_index, (hash, unit_round - 1));
                 }
                 Ok(ReconstructedUnit {
-                unit,
-                parents: parents_with_rounds,
+                    unit,
+                    parents: parents_with_rounds,
                 })
-            },
+            }
             false => Err(unit),
         }
     }
@@ -87,12 +87,18 @@ impl<U: Unit> UnitWithParents for ReconstructedUnit<U> {
     }
 
     fn direct_parents(&self) -> impl Iterator<Item = &HashFor<Self>> {
-        self.parents.values().filter_map(|(hash, parent_round)| {
-            match self.unit.coord().round() {
+        self.parents
+            .values()
+            .filter_map(|(hash, parent_round)| match self.unit.coord().round() {
                 0 => None,
-                unit_round => if unit_round - 1 == *parent_round { Some(hash) } else { None },
-            }
-        })
+                unit_round => {
+                    if unit_round - 1 == *parent_round {
+                        Some(hash)
+                    } else {
+                        None
+                    }
+                }
+            })
     }
 
     fn parent_for(&self, index: NodeIndex) -> Option<&HashFor<Self>> {

--- a/consensus/src/dag/reconstruction/parents.rs
+++ b/consensus/src/dag/reconstruction/parents.rs
@@ -237,7 +237,7 @@ mod test {
             assert_eq!(units.len(), 1);
             let reconstructed_unit = units.pop().expect("just checked its there");
             assert_eq!(reconstructed_unit, ReconstructedUnit::initial(unit.clone()));
-            assert_eq!(reconstructed_unit.parents().item_count(), 0);
+            assert_eq!(reconstructed_unit.parents().count(), 0);
         }
     }
 
@@ -258,15 +258,15 @@ mod test {
                 match round {
                     0 => {
                         assert_eq!(reconstructed_unit, ReconstructedUnit::initial(unit.clone()));
-                        assert_eq!(reconstructed_unit.parents().item_count(), 0);
+                        assert_eq!(reconstructed_unit.parents().count(), 0);
                     }
                     round => {
-                        assert_eq!(reconstructed_unit.parents().item_count(), 4);
+                        assert_eq!(reconstructed_unit.parents().count(), 4);
                         let parents = dag
                             .get((round - 1) as usize)
                             .expect("the parents are there");
                         for (parent, reconstructed_parent) in
-                            parents.iter().zip(reconstructed_unit.parents().values())
+                            parents.iter().zip(reconstructed_unit.parents())
                         {
                             assert_eq!(&parent.hash(), reconstructed_parent);
                         }
@@ -371,11 +371,11 @@ mod test {
         assert!(requests.is_empty());
         assert_eq!(units.len(), 1);
         let reconstructed_unit = units.pop().expect("just checked its there");
-        assert_eq!(reconstructed_unit.parents().item_count(), 4);
+        assert_eq!(reconstructed_unit.parents().count(), 4);
         for (coord, parent_hash) in parent_hashes {
             assert_eq!(
                 Some(&parent_hash),
-                reconstructed_unit.parents().get(coord.creator())
+                reconstructed_unit.parent_for(coord.creator())
             );
         }
     }

--- a/consensus/src/dissemination/responder.rs
+++ b/consensus/src/dissemination/responder.rs
@@ -57,7 +57,6 @@ impl<H: Hasher, D: Data, MK: MultiKeychain> Responder<H, D, MK> {
             .map(|unit| {
                 let parents = unit
                     .parents()
-                    .values()
                     .map(|parent_hash| {
                         units
                             .unit(parent_hash)
@@ -270,8 +269,8 @@ mod test {
         match response {
             Response::Parents(response_hash, parents) => {
                 assert_eq!(response_hash, requested_unit.hash());
-                assert_eq!(parents.len(), requested_unit.parents().size().0);
-                for (parent, parent_hash) in zip(parents, requested_unit.parents().values()) {
+                assert_eq!(parents.len(), requested_unit.parents().count());
+                for (parent, parent_hash) in zip(parents, requested_unit.parents()) {
                     assert_eq!(&parent.as_signable().hash(), parent_hash);
                 }
             }

--- a/consensus/src/extension/election.rs
+++ b/consensus/src/extension/election.rs
@@ -49,11 +49,11 @@ impl<U: UnitWithParents> CandidateElection<U> {
 
     fn parent_votes(
         &mut self,
-        parents: &NodeMap<HashFor<U>>,
+        parents: Vec<HashFor<U>>,
     ) -> Result<(NodeCount, NodeCount), CandidateOutcome<U::Hasher>> {
         let (mut votes_for, mut votes_against) = (NodeCount(0), NodeCount(0));
-        for parent in parents.values() {
-            match self.votes.get(parent).expect("units are added in order") {
+        for parent in parents {
+            match self.votes.get(&parent).expect("units are added in order") {
                 true => votes_for += NodeCount(1),
                 false => votes_against += NodeCount(1),
             }
@@ -63,11 +63,12 @@ impl<U: UnitWithParents> CandidateElection<U> {
 
     fn vote_from_parents(
         &mut self,
-        parents: &NodeMap<HashFor<U>>,
+        parents: Vec<HashFor<U>>,
+        parents_size: NodeCount,
         relative_round: Round,
     ) -> Result<bool, CandidateOutcome<U::Hasher>> {
         use CandidateOutcome::*;
-        let threshold = parents.size().consensus_threshold();
+        let threshold = parents_size.consensus_threshold();
         // Gather parents' votes.
         let (votes_for, votes_against) = self.parent_votes(parents)?;
         assert!(votes_for + votes_against >= threshold);
@@ -102,12 +103,13 @@ impl<U: UnitWithParents> CandidateElection<U> {
             return Ok(());
         }
         let relative_round = voter.round() - self.round;
+        let direct_parents = voter.direct_parents().cloned().collect::<Vec<_>>();
         let vote = match relative_round {
             0 => unreachable!("just checked that voter and election rounds are not equal"),
             // Direct descendands vote for, all other units of that round against.
-            1 => voter.parents().get(self.candidate_creator) == Some(&self.candidate_hash),
+            1 => voter.parent_for(self.candidate_creator) == Some(&self.candidate_hash),
             // Otherwise we compute the vote based on the parents' votes.
-            _ => self.vote_from_parents(voter.parents(), relative_round)?,
+            _ => self.vote_from_parents(direct_parents, voter.parents_size(), relative_round)?,
         };
         self.votes.insert(voter.hash(), vote);
         Ok(())
@@ -360,7 +362,7 @@ mod test {
 
     #[test]
     #[ignore]
-    // TODO(A0-4563) Uncomment after changes to parent voting code
+    // TODO(A0-4559) Uncomment
     fn given_minimal_dag_with_orphaned_node_when_electing_then_orphaned_node_is_not_head() {
         use ElectionResult::*;
         let mut units = Units::new();

--- a/consensus/src/extension/election.rs
+++ b/consensus/src/extension/election.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use crate::{
     extension::units::Units,
     units::{HashFor, UnitWithParents},
-    Hasher, NodeCount, NodeIndex, NodeMap, Round,
+    Hasher, NodeCount, NodeIndex, Round,
 };
 
 fn common_vote(relative_round: Round) -> bool {

--- a/consensus/src/extension/election.rs
+++ b/consensus/src/extension/election.rs
@@ -111,7 +111,7 @@ impl<U: UnitWithParents> CandidateElection<U> {
             _ => {
                 let threshold = voter.node_count().consensus_threshold();
                 self.vote_from_parents(direct_parents, threshold, relative_round)?
-            },
+            }
         };
         self.votes.insert(voter.hash(), vote);
         Ok(())

--- a/consensus/src/extension/election.rs
+++ b/consensus/src/extension/election.rs
@@ -102,7 +102,6 @@ impl<U: UnitWithParents> CandidateElection<U> {
             return Ok(());
         }
         let relative_round = voter.round() - self.round;
-        let direct_parents = voter.direct_parents().cloned().collect();
         let vote = match relative_round {
             0 => unreachable!("just checked that voter and election rounds are not equal"),
             // Direct descendands vote for, all other units of that round against.
@@ -110,6 +109,7 @@ impl<U: UnitWithParents> CandidateElection<U> {
             // Otherwise we compute the vote based on the parents' votes.
             _ => {
                 let threshold = voter.node_count().consensus_threshold();
+                let direct_parents = voter.direct_parents().cloned().collect();
                 self.vote_from_parents(direct_parents, threshold, relative_round)?
             }
         };

--- a/consensus/src/extension/extender.rs
+++ b/consensus/src/extension/extender.rs
@@ -101,7 +101,7 @@ mod test {
 
     #[test]
     #[ignore]
-    // TODO(A0-4563) Uncomment after changes to parent voting code
+    // TODO(A0-4559) Uncomment
     fn given_minimal_dag_with_orphaned_node_when_producing_batches_have_correct_length() {
         let mut extender = Extender::new();
         let n_members = NodeCount(4);

--- a/consensus/src/extension/units.rs
+++ b/consensus/src/extension/units.rs
@@ -64,7 +64,7 @@ impl<U: UnitWithParents> Units<U> {
                 .expect("head is picked among units we have"),
         );
         while let Some(u) = queue.pop_front() {
-            for u_hash in u.parents().clone().into_values() {
+            for u_hash in u.parents() {
                 if let Some(v) = self.units.remove(&u_hash) {
                     queue.push_back(v);
                 }

--- a/consensus/src/extension/units.rs
+++ b/consensus/src/extension/units.rs
@@ -65,7 +65,7 @@ impl<U: UnitWithParents> Units<U> {
         );
         while let Some(u) = queue.pop_front() {
             for u_hash in u.parents() {
-                if let Some(v) = self.units.remove(&u_hash) {
+                if let Some(v) = self.units.remove(u_hash) {
                     queue.push_back(v);
                 }
             }

--- a/consensus/src/testing/dag.rs
+++ b/consensus/src/testing/dag.rs
@@ -147,7 +147,7 @@ impl DagFeeder {
             .parent_hashes()
             .into_iter()
             .collect();
-        
+
         assert_eq!(parents.into_iter().collect::<HashSet<_>>(), expected_hashes);
         self.result.push(unit.clone());
         self.store.insert(unit);

--- a/consensus/src/testing/dag.rs
+++ b/consensus/src/testing/dag.rs
@@ -139,7 +139,7 @@ impl DagFeeder {
 
     fn on_reconstructed_unit(&mut self, unit: ReconstructedUnit) {
         let h = unit.hash();
-        let parents = unit.parents().collect::<Vec<_>>();
+        let parents = unit.parents().cloned().collect::<Vec<_>>();
         let expected_hashes: HashSet<_> = self
             .units_map
             .get(&h)
@@ -147,10 +147,8 @@ impl DagFeeder {
             .parent_hashes()
             .into_iter()
             .collect();
-        assert_eq!(parents.len(), expected_hashes.len());
-        for hash in parents {
-            assert!(expected_hashes.contains(hash));
-        }
+        
+        assert_eq!(parents.into_iter().collect::<HashSet<_>>(), expected_hashes);
         self.result.push(unit.clone());
         self.store.insert(unit);
     }

--- a/consensus/src/testing/dag.rs
+++ b/consensus/src/testing/dag.rs
@@ -139,7 +139,7 @@ impl DagFeeder {
 
     fn on_reconstructed_unit(&mut self, unit: ReconstructedUnit) {
         let h = unit.hash();
-        let parents = unit.parents();
+        let parents = unit.parents().collect::<Vec<_>>();
         let expected_hashes: HashSet<_> = self
             .units_map
             .get(&h)
@@ -147,8 +147,8 @@ impl DagFeeder {
             .parent_hashes()
             .into_iter()
             .collect();
-        assert_eq!(parents.item_count(), expected_hashes.len());
-        for (_, hash) in parents {
+        assert_eq!(parents.len(), expected_hashes.len());
+        for hash in parents {
             assert!(expected_hashes.contains(hash));
         }
         self.result.push(unit.clone());

--- a/consensus/src/testing/dag.rs
+++ b/consensus/src/testing/dag.rs
@@ -139,7 +139,7 @@ impl DagFeeder {
 
     fn on_reconstructed_unit(&mut self, unit: ReconstructedUnit) {
         let h = unit.hash();
-        let parents = unit.parents().cloned().collect::<Vec<_>>();
+        let parents: HashSet<_> = unit.parents().cloned().collect();
         let expected_hashes: HashSet<_> = self
             .units_map
             .get(&h)
@@ -148,7 +148,7 @@ impl DagFeeder {
             .into_iter()
             .collect();
 
-        assert_eq!(parents.into_iter().collect::<HashSet<_>>(), expected_hashes);
+        assert_eq!(parents, expected_hashes);
         self.result.push(unit.clone());
         self.store.insert(unit);
     }

--- a/consensus/src/units/mod.rs
+++ b/consensus/src/units/mod.rs
@@ -221,8 +221,6 @@ pub trait UnitWithParents: Unit {
     fn parents_size(&self) -> NodeCount;
 }
 
-
-
 impl<H: Hasher, D: Data> Unit for FullUnit<H, D> {
     type Hasher = H;
 

--- a/consensus/src/units/mod.rs
+++ b/consensus/src/units/mod.rs
@@ -215,8 +215,13 @@ pub trait WrappedUnit<H: Hasher>: Unit<Hasher = H> {
 }
 
 pub trait UnitWithParents: Unit {
-    fn parents(&self) -> &NodeMap<HashFor<Self>>;
+    fn parents(&self) -> impl Iterator<Item = &HashFor<Self>>;
+    fn direct_parents(&self) -> impl Iterator<Item = &HashFor<Self>>;
+    fn parent_for(&self, index: NodeIndex) -> Option<&HashFor<Self>>;
+    fn parents_size(&self) -> NodeCount;
 }
+
+
 
 impl<H: Hasher, D: Data> Unit for FullUnit<H, D> {
     type Hasher = H;

--- a/consensus/src/units/mod.rs
+++ b/consensus/src/units/mod.rs
@@ -218,7 +218,7 @@ pub trait UnitWithParents: Unit {
     fn parents(&self) -> impl Iterator<Item = &HashFor<Self>>;
     fn direct_parents(&self) -> impl Iterator<Item = &HashFor<Self>>;
     fn parent_for(&self, index: NodeIndex) -> Option<&HashFor<Self>>;
-    fn parents_size(&self) -> NodeCount;
+    fn node_count(&self) -> NodeCount;
 }
 
 impl<H: Hasher, D: Data> Unit for FullUnit<H, D> {

--- a/consensus/src/units/testing.rs
+++ b/consensus/src/units/testing.rs
@@ -241,7 +241,7 @@ pub fn minimal_reconstructed_dag_units_up_to(
         .clone();
     let inactive_node = inactive_node_first_and_last_seen_unit.creator();
     for r in 1..=round {
-        let direct_parents: Vec<TestingDagUnit> = dag
+        let mut parents: Vec<TestingDagUnit> = dag
             .last()
             .expect("previous round present")
             .clone()
@@ -250,7 +250,6 @@ pub fn minimal_reconstructed_dag_units_up_to(
             .choose_multiple(&mut rng, threshold)
             .into_iter()
             .collect();
-        let mut parents = direct_parents.clone();
         if r == round {
             let ancestor_unit = dag
                 .first()

--- a/consensus/src/units/testing.rs
+++ b/consensus/src/units/testing.rs
@@ -263,7 +263,7 @@ pub fn minimal_reconstructed_dag_units_up_to(
             .into_iterator()
             .filter(|node_id| node_id != &inactive_node)
             .map(|node_id| {
-                random_reconstructed_unit_with_parents(node_id, &parents,  &keychains[node_id.0], r)
+                random_reconstructed_unit_with_parents(node_id, &parents, &keychains[node_id.0], r)
             })
             .collect();
         dag.push(units);

--- a/consensus/src/units/testing.rs
+++ b/consensus/src/units/testing.rs
@@ -241,7 +241,7 @@ pub fn minimal_reconstructed_dag_units_up_to(
         .clone();
     let inactive_node = inactive_node_first_and_last_seen_unit.creator();
     for r in 1..=round {
-        let mut parents: Vec<TestingDagUnit> = dag
+        let direct_parents: Vec<TestingDagUnit> = dag
             .last()
             .expect("previous round present")
             .clone()
@@ -250,6 +250,7 @@ pub fn minimal_reconstructed_dag_units_up_to(
             .choose_multiple(&mut rng, threshold)
             .into_iter()
             .collect();
+        let mut parents = direct_parents.clone();
         if r == round {
             let ancestor_unit = dag
                 .first()
@@ -262,7 +263,7 @@ pub fn minimal_reconstructed_dag_units_up_to(
             .into_iterator()
             .filter(|node_id| node_id != &inactive_node)
             .map(|node_id| {
-                random_reconstructed_unit_with_parents(node_id, &parents, &keychains[node_id.0], r)
+                random_reconstructed_unit_with_parents(node_id, &parents,  &keychains[node_id.0], r)
             })
             .collect();
         dag.push(units);


### PR DESCRIPTION
This PR extends `UnitWithParents` trait so that it will be possible to distinguish direct and non-direct parents of a unit. Those changes are required for later changes in DAG reconstruction and validation. This change must be a no-op from the algorithm perspective. I am not going to uncomment UT added recently just yet, 