### PR TITLE
Enable orphaned node tests in extension module

### DIFF
--- a/consensus/src/extension/election.rs
+++ b/consensus/src/extension/election.rs
@@ -363,7 +363,6 @@ mod test {
     }
 
     #[test]
-    #[ignore]
     // TODO(A0-4559) Uncomment
     fn given_minimal_dag_with_orphaned_node_when_electing_then_orphaned_node_is_not_head() {
         use ElectionResult::*;

--- a/consensus/src/extension/extender.rs
+++ b/consensus/src/extension/extender.rs
@@ -100,7 +100,6 @@ mod test {
     }
 
     #[test]
-    #[ignore]
     // TODO(A0-4559) Uncomment
     fn given_minimal_dag_with_orphaned_node_when_producing_batches_have_correct_length() {
         let mut extender = Extender::new();


### PR DESCRIPTION
Re-enable two previously ignored tests related to orphaned nodes:
- given_minimal_dag_with_orphaned_node_when_producing_batches_have_correct_length in extender.rs
- given_minimal_dag_with_orphaned_node_when_electing_then_orphaned_node_is_not_head in election.rs

These tests verify the correct handling of orphaned nodes in the DAG structure,
improving test coverage for edge cases in the consensus mechanism.

Resolves: A0-4559