### PR TITLE
Uncomment orphaned node tests (A0-4559)

### DIFF
--- a/consensus/src/extension/election.rs
+++ b/consensus/src/extension/election.rs
@@ -363,8 +363,6 @@ mod test {
     }
 
     #[test]
-    #[ignore]
-    // TODO(A0-4559) Uncomment
     fn given_minimal_dag_with_orphaned_node_when_electing_then_orphaned_node_is_not_head() {
         use ElectionResult::*;
         let mut units = Units::new();

--- a/consensus/src/extension/extender.rs
+++ b/consensus/src/extension/extender.rs
@@ -100,8 +100,6 @@ mod test {
     }
 
     #[test]
-    #[ignore]
-    // TODO(A0-4559) Uncomment
     fn given_minimal_dag_with_orphaned_node_when_producing_batches_have_correct_length() {
         let mut extender = Extender::new();
         let n_members = NodeCount(4);


### PR DESCRIPTION
Uncommented two test cases that verify correct handling of orphaned nodes in DAG:
- Test for correct batch length with orphaned nodes in Extender
- Test for proper head election with orphaned nodes in RoundElection