### PR TITLE
INFRA-205: Bump GitHub runners to 24.04

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   build:
     name: Run `cargo-audit`
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4

--- a/.github/workflows/check-version-bumped-consensus.yml
+++ b/.github/workflows/check-version-bumped-consensus.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   main:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: GIT | Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/check-version-bumped-crypto.yml
+++ b/.github/workflows/check-version-bumped-crypto.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   main:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: GIT | Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/check-version-bumped-mock.yml
+++ b/.github/workflows/check-version-bumped-mock.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   main:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: GIT | Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/check-version-bumped-rmc.yml
+++ b/.github/workflows/check-version-bumped-rmc.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   main:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: GIT | Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/check-version-bumped-types.yml
+++ b/.github/workflows/check-version-bumped-types.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   main:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: GIT | Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
   pr:
     name: pull_request
     if: "github.event_name == 'pull_request'"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: lint
     steps:
       - name: checkout the source code
@@ -39,7 +39,7 @@ jobs:
   master:
     name: push
     if: "github.event_name == 'push'"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: lint
     steps:
       - name: checkout the source code
@@ -57,7 +57,7 @@ jobs:
           args: '--lib'
   lint:
     name: lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout the source code
         uses: actions/checkout@v4

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Setup mdBook

--- a/.github/workflows/post-dod-checklist.yml
+++ b/.github/workflows/post-dod-checklist.yml
@@ -2,7 +2,7 @@ name: Post DoD checklist
 on: [pull_request_target]
 jobs:
   run:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: wow-actions/auto-comment@v1
         with:

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   publish:
     environment: Autobump version
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ github.repository == 'Cardinal-Cryptography/AlephBFT'}}
     steps:
       - name: Publish

--- a/.github/workflows/push-foundation-repo.yml
+++ b/.github/workflows/push-foundation-repo.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   sync:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ github.repository == 'Cardinal-Cryptography/AlephBFT'}}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/readme-cargo-toml-versions-aligned-consensus.yml
+++ b/.github/workflows/readme-cargo-toml-versions-aligned-consensus.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   readme-cargo-toml-versions-aligned-consensus:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
# Description

See https://github.com/actions/runner-images/issues/11101

Full `sed`. CI pass - it works!

https://github.com/Cardinal-Cryptography/AlephBFT/actions/runs/14107765268/job/39518251771?pr=550 fails in `main`, please ignore

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
