### PR TITLE
A0-4383: Move LocalIO into its own submodule

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "aleph-bft"
-version = "0.44.1"
+version = "0.44.2"
 dependencies = [
  "aleph-bft-mock",
  "aleph-bft-rmc",

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aleph-bft"
-version = "0.44.1"
+version = "0.44.2"
 edition = "2021"
 authors = ["Cardinal Cryptography"]
 categories = ["algorithms", "data-structures", "cryptography", "database"]

--- a/consensus/src/interface.rs
+++ b/consensus/src/interface.rs
@@ -1,0 +1,105 @@
+use crate::{
+    Data, DataProvider, FinalizationHandler, Hasher, OrderedUnit, UnitFinalizationHandler,
+};
+use futures::{AsyncRead, AsyncWrite};
+use std::marker::PhantomData;
+
+/// This adapter allows to map an implementation of [`FinalizationHandler`] onto implementation of [`UnitFinalizationHandler`].
+pub struct FinalizationHandlerAdapter<FH, D, H> {
+    finalization_handler: FH,
+    _phantom: PhantomData<(D, H)>,
+}
+
+impl<FH, D, H> From<FH> for FinalizationHandlerAdapter<FH, D, H> {
+    fn from(value: FH) -> Self {
+        Self {
+            finalization_handler: value,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<D: Data, H: Hasher, FH: FinalizationHandler<D>> UnitFinalizationHandler
+    for FinalizationHandlerAdapter<FH, D, H>
+{
+    type Data = D;
+    type Hasher = H;
+
+    fn batch_finalized(&mut self, batch: Vec<OrderedUnit<Self::Data, Self::Hasher>>) {
+        for unit in batch {
+            if let Some(data) = unit.data {
+                self.finalization_handler.data_finalized(data)
+            }
+        }
+    }
+}
+
+/// The local interface of the consensus algorithm. Contains a [`DataProvider`] as a source of data
+/// to order, a [`UnitFinalizationHandler`] for handling ordered units, and a pair of read/write
+/// structs intended for saving and restorin the state of the algorithm within the session, as a
+/// contingency in the case of a crash.
+#[derive(Clone)]
+pub struct LocalIO<DP: DataProvider, UFH: UnitFinalizationHandler, US: AsyncWrite, UL: AsyncRead> {
+    data_provider: DP,
+    finalization_handler: UFH,
+    unit_saver: US,
+    unit_loader: UL,
+}
+
+impl<
+        H: Hasher,
+        DP: DataProvider,
+        FH: FinalizationHandler<DP::Output>,
+        US: AsyncWrite,
+        UL: AsyncRead,
+    > LocalIO<DP, FinalizationHandlerAdapter<FH, DP::Output, H>, US, UL>
+{
+    /// Create a new local interface. Note that this uses the simplified, and recommended,
+    /// finalization handler that only deals with ordered data.
+    pub fn new(
+        data_provider: DP,
+        finalization_handler: FH,
+        unit_saver: US,
+        unit_loader: UL,
+    ) -> Self {
+        Self {
+            data_provider,
+            finalization_handler: finalization_handler.into(),
+            unit_saver,
+            unit_loader,
+        }
+    }
+}
+
+impl<DP: DataProvider, UFH: UnitFinalizationHandler, US: AsyncWrite, UL: AsyncRead>
+    LocalIO<DP, UFH, US, UL>
+{
+    /// Create a new local interface, providing a full implementation of a
+    /// [`UnitFinalizationHandler`].Implementing [`UnitFinalizationHandler`] directly is more
+    /// complex, and should be unnecessary for most usecases. Implement [`FinalizationHandler`]
+    /// and use `new` instead, unless you absolutely know what you are doing.
+    pub fn new_with_unit_finalization_handler(
+        data_provider: DP,
+        finalization_handler: UFH,
+        unit_saver: US,
+        unit_loader: UL,
+    ) -> Self {
+        Self {
+            data_provider,
+            finalization_handler,
+            unit_saver,
+            unit_loader,
+        }
+    }
+
+    /// Disassemble the interface into components.
+    pub fn into_components(self) -> (DP, UFH, US, UL) {
+        let LocalIO {
+            data_provider,
+            finalization_handler,
+            unit_saver,
+            unit_loader,
+        } = self;
+        (data_provider, finalization_handler, unit_saver, unit_loader)
+    }
+}

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -9,6 +9,7 @@ mod creation;
 mod dag;
 mod dissemination;
 mod extension;
+mod interface;
 mod member;
 mod network;
 mod runway;
@@ -30,7 +31,8 @@ pub use aleph_bft_types::{
 pub use config::{
     create_config, default_config, default_delay_config, exponential_slowdown, Config, DelayConfig,
 };
-pub use member::{run_session, LocalIO};
+pub use interface::LocalIO;
+pub use member::run_session;
 pub use network::NetworkData;
 pub use terminator::{handle_task_termination, Terminator};
 


### PR DESCRIPTION
Tiny PR, first of a couple. They should end with member & runway being completely replaced.