### PR TITLE
fix dependency issues and rustc warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,12 +53,10 @@ dependencies = [
 name = "aleph-bft-crypto"
 version = "0.11.0"
 dependencies = [
- "async-trait",
  "bit-vec",
  "derive_more",
  "log",
  "parity-scale-codec",
- "tokio",
 ]
 
 [[package]]
@@ -75,10 +73,8 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot",
- "sha3",
  "time",
  "tokio",
- "unsigned-varint",
 ]
 
 [[package]]
@@ -214,19 +210,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "asynchronous-codec"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a860072022177f903e59730004fb5dc13db9275b79bb2aef7ba8ce831956c233"
-dependencies = [
- "bytes",
- "futures-sink",
- "futures-util",
- "memchr",
- "pin-project-lite",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -258,15 +241,6 @@ name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
 
 [[package]]
 name = "byte-slice-cast"
@@ -362,25 +336,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "crypto-common"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
 name = "deranged"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,16 +375,6 @@ dependencies = [
  "quote",
  "syn 2.0.100",
  "unicode-xid",
-]
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
 ]
 
 [[package]]
@@ -563,16 +508,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -665,15 +600,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
-]
-
-[[package]]
-name = "keccak"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
-dependencies = [
- "cpufeatures",
 ]
 
 [[package]]
@@ -1019,16 +945,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha3"
-version = "0.10.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
-dependencies = [
- "digest",
- "keccak",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1193,12 +1109,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "typenum"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1217,28 +1127,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "unsigned-varint"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
-dependencies = [
- "asynchronous-codec",
- "bytes",
- "futures-io",
- "futures-util",
-]
-
-[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 
 members = [
 

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -12,11 +12,9 @@ readme = "./README.md"
 description = "Utilities for node addressing and message signing in the aleph-bft package."
 
 [dependencies]
-async-trait = "0.1"
 bit-vec = "0.8"
 codec = { package = "parity-scale-codec", version = "3.0", default-features = false, features = ["derive"] }
 derive_more = { version = "1.0", features = ["full"] }
 log = "0.4"
 
 [dev-dependencies]
-tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }

--- a/crypto/src/signature.rs
+++ b/crypto/src/signature.rs
@@ -39,7 +39,6 @@ pub trait Keychain: Index + Clone + Send + Sync + 'static {
 pub trait PartialMultisignature: Signature {
     type Signature: Signature;
     /// Adds the signature.
-    #[must_use = "consumes the original and returns the aggregated signature which should be used"]
     fn add_signature(self, signature: &Self::Signature, index: NodeIndex) -> Self;
 }
 
@@ -65,7 +64,6 @@ pub type SignatureSet<S> = NodeMap<S>;
 impl<S: Signature> PartialMultisignature for SignatureSet<S> {
     type Signature = S;
 
-    #[must_use = "consumes the original and returns the aggregated signature which should be used"]
     fn add_signature(mut self, signature: &Self::Signature, index: NodeIndex) -> Self {
         self.insert(index, signature.clone());
         self
@@ -398,7 +396,6 @@ impl<T: Signable, MK: MultiKeychain> PartiallyMultisigned<T, MK> {
     }
 
     /// Adds a signature and checks if multisignature is complete.
-    #[must_use = "consumes the original and returns the aggregated signature which should be used"]
     pub fn add_signature(self, signed: Signed<Indexed<T>, MK>, keychain: &MK) -> Self {
         if self.as_signable().hash().as_ref() != signed.as_signable().hash().as_ref() {
             warn!(target: "AlephBFT-signed", "Tried to add a signature of a different object");

--- a/examples/blockchain/Cargo.toml
+++ b/examples/blockchain/Cargo.toml
@@ -17,7 +17,5 @@ futures = "0.3"
 futures-timer = "3.0"
 log = "0.4"
 parking_lot = "0.12"
-sha3 = "0.10"
 time = { version = "0.3", features = ["formatting", "macros", "local-offset"] }
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "io-util", "net", "time"] }
-unsigned-varint = { version = "0.8.0", features = ["futures", "asynchronous_codec"] }


### PR DESCRIPTION
###Description
- Remove unused dependencies:
  - aleph-bft-crypto: async-trait, tokio
  - aleph-bft-examples-blockchain: sha3, unsigned-varint
- Remove ineffective #[must_use] attributes from trait methods
- Set workspace resolver to "2" to match edition 2021

All tests continue to pass. Verified with cargo +nightly udeps.